### PR TITLE
Allow slow Gitee release uploads

### DIFF
--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Fetch all GitHub branches and tags
         shell: bash


### PR DESCRIPTION
## Summary

Increase the Gitee mirror job timeout from 90 to 120 minutes.

## Why

The successful retention repair run took about 85 minutes. Gitee needed roughly 77 minutes to accept and verify the 52.5 MB `v3.1.16/Siming.exe`, leaving too little margin under the previous 90-minute job limit for future network variation.

## Validation

- Parsed the workflow YAML and asserted `jobs.sync.timeout-minutes == 120`.
- Ran `git diff --check`.