### PR TITLE
Windows 安装包与安装版自动更新

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -8,10 +8,9 @@ on:
       - ".github/workflows/release-gate.yml"
       - "build-installer.bat"
       - "installer/**"
+      - "scripts/build-exe.ps1"
       - "scripts/build-installer.ps1"
-      - "scripts/sign-windows-release.ps1"
       - "scripts/sign-windows-installer.ps1"
-      - "scripts/verify-release-assets.ps1"
       - "scripts/verify-windows-installer.ps1"
       - "scripts/publish-github.ps1"
       - "backend/app/installer_updater.py"
@@ -139,9 +138,18 @@ jobs:
         working-directory: frontend
         run: npm run api:check
 
-      - name: Build Windows distributions
+      - name: Build Windows installer
         shell: cmd
         run: build-installer.bat
+
+      - name: Reject stale legacy Windows release assets
+        shell: pwsh
+        run: |
+          $legacyAssets = @("release\Siming.exe", "release\update.json", "release\sha256.txt")
+          $found = @($legacyAssets | Where-Object { Test-Path -LiteralPath $_ })
+          if ($found.Count -gt 0) {
+            throw "Legacy Windows release assets must not be emitted: $($found -join ', ')"
+          }
 
       - name: Prepare Android signing key
         shell: pwsh
@@ -163,7 +171,7 @@ jobs:
         shell: pwsh
         run: ./scripts/build-android-release.ps1
 
-      - name: Sign Windows distributions when a trusted certificate is configured
+      - name: Sign Windows installer when a trusted certificate is configured
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         shell: pwsh
         env:
@@ -184,12 +192,6 @@ jobs:
           $certificatePath = Join-Path $env:RUNNER_TEMP "siming-windows-codesign.pfx"
           try {
             [IO.File]::WriteAllBytes($certificatePath, [Convert]::FromBase64String($env:WINDOWS_CODESIGN_PFX_BASE64))
-            $version = (Get-Content frontend/package.json -Raw | ConvertFrom-Json).version
-            ./scripts/sign-windows-release.ps1 `
-              -ReleaseDir release `
-              -CertificatePath $certificatePath `
-              -CertificatePassword $env:WINDOWS_CODESIGN_PASSWORD `
-              -ExpectedVersion $version
             ./scripts/sign-windows-installer.ps1 `
               -ReleaseDir release `
               -CertificatePath $certificatePath `
@@ -201,23 +203,19 @@ jobs:
             }
           }
 
-      - name: Verify package assets and run smoke test
+      - name: Verify package assets
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           $version = (Get-Content frontend/package.json -Raw | ConvertFrom-Json).version
           if ($env:SIMING_WINDOWS_RELEASE_SIGNED -eq "1") {
-            ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version -RequireTrustedSignature
             ./scripts/verify-windows-installer.ps1 -ReleaseDir release -RequireTrustedSignature
           } elseif ("${{ github.ref_type }}" -eq "tag" -or "${{ github.event_name }}" -eq "workflow_dispatch") {
-            ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version -AllowUnsignedManualRelease
             ./scripts/verify-windows-installer.ps1 -ReleaseDir release -AllowUnsignedManualRelease
           } else {
-            ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version
             ./scripts/verify-windows-installer.ps1 -ReleaseDir release
           }
           ./scripts/verify-android-release.ps1 -ReleaseDir release -ExpectedVersion $version
-          ./scripts/smoke-test-release.ps1 -SkipBuild
 
       - name: Smoke install Windows package
         shell: pwsh
@@ -241,6 +239,10 @@ jobs:
           if (-not (Test-Path -LiteralPath (Join-Path $installDir ".siming-installed") -PathType Leaf)) {
             throw "Installer smoke did not create the installed-layout marker."
           }
+          $uninstaller = Join-Path $installDir "unins000.exe"
+          if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+            throw "Installer smoke did not create an uninstaller."
+          }
 
       - name: Upload verified release assets
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
@@ -248,9 +250,6 @@ jobs:
         with:
           name: release-assets-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           path: |
-            release/Siming.exe
-            release/update.json
-            release/sha256.txt
             release/Siming-Setup.exe
             release/Siming-Setup.sha256
             release/Siming.apk
@@ -265,12 +264,9 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $version = (Get-Content frontend/package.json -Raw | ConvertFrom-Json).version
-          $tag = if ("${{ github.ref_type }}" -eq "tag") { "${{ github.ref_name }}" } else { "v$version" }
+          $tag = "${{ github.ref_name }}"
           $notesPath = "docs/release-notes-$version.md"
           $assets = @(
-            "release/Siming.exe",
-            "release/update.json",
-            "release/sha256.txt",
             "release/Siming-Setup.exe",
             "release/Siming-Setup.sha256",
             "release/Siming.apk",
@@ -280,6 +276,14 @@ jobs:
           gh release view $tag -R "${{ github.repository }}" *> $null
           if ($LASTEXITCODE -eq 0) { $releaseExists = $true }
           if ($releaseExists) {
+            $existing = gh release view $tag -R "${{ github.repository }}" --json assets | ConvertFrom-Json
+            $existingNames = @($existing.assets | ForEach-Object { $_.name })
+            foreach ($legacyAsset in @("Siming.exe", "update.json", "sha256.txt", "Moshu.exe", "NovelWritingAgent.exe")) {
+              if ($existingNames -contains $legacyAsset) {
+                gh release delete-asset $tag $legacyAsset -R "${{ github.repository }}" -y
+                if ($LASTEXITCODE -ne 0) { throw "Failed to delete legacy release asset $legacyAsset." }
+              }
+            }
             gh release upload $tag @assets -R "${{ github.repository }}" --clobber
           } elseif (Test-Path -LiteralPath $notesPath) {
             gh release create $tag @assets -R "${{ github.repository }}" --title "司命 $version" --notes-file $notesPath
@@ -313,22 +317,26 @@ jobs:
           $ErrorActionPreference = "Stop"
           $tag = "${{ github.event.release.tag_name }}"
           $version = $tag.TrimStart("v")
-          $expectedAssets = @("Siming.exe", "update.json", "sha256.txt", "Siming-Setup.exe", "Siming-Setup.sha256", "Siming.apk", "Siming-apk-sha256.txt")
+          $expectedAssets = @("Siming-Setup.exe", "Siming-Setup.sha256", "Siming.apk", "Siming-apk-sha256.txt")
+          $forbiddenAssets = @("Siming.exe", "update.json", "sha256.txt")
           $verified = $false
           New-Item -ItemType Directory -Force -Path release | Out-Null
           for ($attempt = 1; $attempt -le 18; $attempt++) {
             $release = gh release view $tag -R "${{ github.repository }}" --json assets | ConvertFrom-Json
             $availableAssets = @($release.assets | ForEach-Object { $_.name })
             $missingAssets = @($expectedAssets | Where-Object { $_ -notin $availableAssets })
+            $forbiddenFound = @($forbiddenAssets | Where-Object { $_ -in $availableAssets })
+            if ($forbiddenFound.Count -gt 0) {
+              throw "Published release contains legacy Windows assets: $($forbiddenFound -join ', ')"
+            }
             if ($missingAssets.Count -gt 0) {
               Write-Host "Waiting for published assets ($attempt/18): $($missingAssets -join ', ')"
               Start-Sleep -Seconds 10
               continue
             }
             try {
-              gh release download $tag -R "${{ github.repository }}" -p "Siming.exe" -p "update.json" -p "sha256.txt" -p "Siming-Setup.exe" -p "Siming-Setup.sha256" -p "Siming.apk" -p "Siming-apk-sha256.txt" -D release --clobber
+              gh release download $tag -R "${{ github.repository }}" -p "Siming-Setup.exe" -p "Siming-Setup.sha256" -p "Siming.apk" -p "Siming-apk-sha256.txt" -D release --clobber
               if ($LASTEXITCODE -ne 0) { throw "gh release download failed with exit code $LASTEXITCODE" }
-              ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version -AllowUnsignedManualRelease
               ./scripts/verify-windows-installer.ps1 -ReleaseDir release -AllowUnsignedManualRelease
               ./scripts/verify-android-release.ps1 -ReleaseDir release -ExpectedVersion $version
               $verified = $true

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -6,9 +6,15 @@ on:
     tags: ["v*"]
     paths:
       - ".github/workflows/release-gate.yml"
+      - "build-installer.bat"
+      - "installer/**"
+      - "scripts/build-installer.ps1"
       - "scripts/sign-windows-release.ps1"
+      - "scripts/sign-windows-installer.ps1"
       - "scripts/verify-release-assets.ps1"
+      - "scripts/verify-windows-installer.ps1"
       - "scripts/publish-github.ps1"
+      - "backend/app/installer_updater.py"
       - "backend/app/version.py"
       - "frontend/package.json"
       - "mobile/android/app/build.gradle.kts"
@@ -70,6 +76,10 @@ jobs:
         shell: pwsh
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0"
 
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --yes --no-progress
+
       - name: Verify tag matches application version
         shell: pwsh
         run: |
@@ -120,7 +130,7 @@ jobs:
         working-directory: backend
         run: |
           python scripts/run_quality.py
-          python -m pytest tests/test_architecture_foundation.py tests/test_config_llm.py tests/test_novel_creation_workspace_v2.py tests/test_packaging_contract.py tests/test_release_packaging_contract.py
+          python -m pytest tests/test_architecture_foundation.py tests/test_config_llm.py tests/test_novel_creation_workspace_v2.py tests/test_packaging_contract.py tests/test_release_packaging_contract.py tests/test_installer_updater.py tests/test_windows_installer_contract.py
 
       - name: Validate performance baseline
         run: python scripts/run-performance-baseline.py --output .build/performance.json
@@ -129,9 +139,9 @@ jobs:
         working-directory: frontend
         run: npm run api:check
 
-      - name: Build distributable
+      - name: Build Windows distributions
         shell: cmd
-        run: build-exe.bat
+        run: build-installer.bat
 
       - name: Prepare Android signing key
         shell: pwsh
@@ -153,7 +163,7 @@ jobs:
         shell: pwsh
         run: ./scripts/build-android-release.ps1
 
-      - name: Sign Windows executable when a trusted certificate is configured
+      - name: Sign Windows distributions when a trusted certificate is configured
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         shell: pwsh
         env:
@@ -180,6 +190,10 @@ jobs:
               -CertificatePath $certificatePath `
               -CertificatePassword $env:WINDOWS_CODESIGN_PASSWORD `
               -ExpectedVersion $version
+            ./scripts/sign-windows-installer.ps1 `
+              -ReleaseDir release `
+              -CertificatePath $certificatePath `
+              -CertificatePassword $env:WINDOWS_CODESIGN_PASSWORD
             "SIMING_WINDOWS_RELEASE_SIGNED=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           } finally {
             if (Test-Path -LiteralPath $certificatePath) {
@@ -194,13 +208,39 @@ jobs:
           $version = (Get-Content frontend/package.json -Raw | ConvertFrom-Json).version
           if ($env:SIMING_WINDOWS_RELEASE_SIGNED -eq "1") {
             ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version -RequireTrustedSignature
+            ./scripts/verify-windows-installer.ps1 -ReleaseDir release -RequireTrustedSignature
           } elseif ("${{ github.ref_type }}" -eq "tag" -or "${{ github.event_name }}" -eq "workflow_dispatch") {
             ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version -AllowUnsignedManualRelease
+            ./scripts/verify-windows-installer.ps1 -ReleaseDir release -AllowUnsignedManualRelease
           } else {
             ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version
+            ./scripts/verify-windows-installer.ps1 -ReleaseDir release
           }
           ./scripts/verify-android-release.ps1 -ReleaseDir release -ExpectedVersion $version
           ./scripts/smoke-test-release.ps1 -SkipBuild
+
+      - name: Smoke install Windows package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installDir = Join-Path $env:RUNNER_TEMP "SimingInstallerSmoke"
+          Remove-Item -LiteralPath $installDir -Recurse -Force -ErrorAction SilentlyContinue
+          $process = Start-Process -FilePath (Resolve-Path "release\Siming-Setup.exe") -ArgumentList @(
+            "/SP-",
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART",
+            "/SIMINGNOLAUNCH=1",
+            "/MERGETASKS=!desktopicon",
+            "/DIR=$installDir"
+          ) -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "Installer smoke failed with exit code $($process.ExitCode)." }
+          if (-not (Test-Path -LiteralPath (Join-Path $installDir "Siming.exe") -PathType Leaf)) {
+            throw "Installer smoke did not create Siming.exe."
+          }
+          if (-not (Test-Path -LiteralPath (Join-Path $installDir ".siming-installed") -PathType Leaf)) {
+            throw "Installer smoke did not create the installed-layout marker."
+          }
 
       - name: Upload verified release assets
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
@@ -211,6 +251,8 @@ jobs:
             release/Siming.exe
             release/update.json
             release/sha256.txt
+            release/Siming-Setup.exe
+            release/Siming-Setup.sha256
             release/Siming.apk
             release/Siming-apk-sha256.txt
           if-no-files-found: error
@@ -229,6 +271,8 @@ jobs:
             "release/Siming.exe",
             "release/update.json",
             "release/sha256.txt",
+            "release/Siming-Setup.exe",
+            "release/Siming-Setup.sha256",
             "release/Siming.apk",
             "release/Siming-apk-sha256.txt"
           )
@@ -269,7 +313,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $tag = "${{ github.event.release.tag_name }}"
           $version = $tag.TrimStart("v")
-          $expectedAssets = @("Siming.exe", "update.json", "sha256.txt", "Siming.apk", "Siming-apk-sha256.txt")
+          $expectedAssets = @("Siming.exe", "update.json", "sha256.txt", "Siming-Setup.exe", "Siming-Setup.sha256", "Siming.apk", "Siming-apk-sha256.txt")
           $verified = $false
           New-Item -ItemType Directory -Force -Path release | Out-Null
           for ($attempt = 1; $attempt -le 18; $attempt++) {
@@ -282,9 +326,10 @@ jobs:
               continue
             }
             try {
-              gh release download $tag -R "${{ github.repository }}" -p "Siming.exe" -p "update.json" -p "sha256.txt" -p "Siming.apk" -p "Siming-apk-sha256.txt" -D release --clobber
+              gh release download $tag -R "${{ github.repository }}" -p "Siming.exe" -p "update.json" -p "sha256.txt" -p "Siming-Setup.exe" -p "Siming-Setup.sha256" -p "Siming.apk" -p "Siming-apk-sha256.txt" -D release --clobber
               if ($LASTEXITCODE -ne 0) { throw "gh release download failed with exit code $LASTEXITCODE" }
               ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version -AllowUnsignedManualRelease
+              ./scripts/verify-windows-installer.ps1 -ReleaseDir release -AllowUnsignedManualRelease
               ./scripts/verify-android-release.ps1 -ReleaseDir release -ExpectedVersion $version
               $verified = $true
               break

--- a/.github/workflows/windows-installer-ci.yml
+++ b/.github/workflows/windows-installer-ci.yml
@@ -1,0 +1,103 @@
+name: Windows Installer CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-installer-ci.yml"
+      - "build-installer.bat"
+      - "installer/**"
+      - "scripts/build-exe.ps1"
+      - "scripts/build-installer.ps1"
+      - "scripts/verify-release-assets.ps1"
+      - "scripts/verify-windows-installer.ps1"
+      - "backend/launcher.py"
+      - "backend/app/installer_updater.py"
+      - "backend/app/updater.py"
+      - "backend/app/routers/application_updates.py"
+      - "backend/tests/test_installer_updater.py"
+      - "backend/tests/test_windows_installer_contract.py"
+  workflow_dispatch:
+
+jobs:
+  build-and-install:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      MOSHU_DISABLE_AUTO_MCP_SETUP: "1"
+      SIMING_ENABLE_LOCAL_RUNTIME: "0"
+      OPENAI_API_KEY: test-placeholder
+      ANTHROPIC_API_KEY: test-placeholder
+      ARK_API_KEY: test-placeholder
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --yes --no-progress
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install backend test dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Test installer update contracts
+        working-directory: backend
+        run: python -m pytest tests/test_updater.py tests/test_installer_updater.py tests/test_packaging_contract.py tests/test_release_packaging_contract.py tests/test_windows_installer_contract.py
+
+      - name: Build portable bridge and installer
+        shell: cmd
+        run: build-installer.bat
+
+      - name: Verify unsigned PR artifacts
+        shell: pwsh
+        run: |
+          $version = (Get-Content frontend/package.json -Raw | ConvertFrom-Json).version
+          ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version
+          ./scripts/verify-windows-installer.ps1 -ReleaseDir release
+          ./scripts/smoke-test-release.ps1 -SkipBuild
+
+      - name: Smoke install selectable-path package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installDir = Join-Path $env:RUNNER_TEMP "SimingInstallerSmoke"
+          Remove-Item -LiteralPath $installDir -Recurse -Force -ErrorAction SilentlyContinue
+          $process = Start-Process -FilePath (Resolve-Path "release\Siming-Setup.exe") -ArgumentList @(
+            "/SP-",
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART",
+            "/SIMINGNOLAUNCH=1",
+            "/MERGETASKS=!desktopicon",
+            "/DIR=$installDir"
+          ) -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "Installer smoke failed with exit code $($process.ExitCode)." }
+          if (-not (Test-Path -LiteralPath (Join-Path $installDir "Siming.exe") -PathType Leaf)) {
+            throw "Installer smoke did not create Siming.exe."
+          }
+          if (-not (Test-Path -LiteralPath (Join-Path $installDir ".siming-installed") -PathType Leaf)) {
+            throw "Installer smoke did not create the installed-layout marker."
+          }
+          $uninstaller = Join-Path $installDir "unins000.exe"
+          if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+            throw "Installer smoke did not create an uninstaller."
+          }

--- a/.github/workflows/windows-installer-ci.yml
+++ b/.github/workflows/windows-installer-ci.yml
@@ -101,3 +101,13 @@ jobs:
           if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
             throw "Installer smoke did not create an uninstaller."
           }
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: Siming-Windows-Installer
+          path: |
+            release/Siming-Setup.exe
+            release/Siming-Setup.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/windows-installer-ci.yml
+++ b/.github/workflows/windows-installer-ci.yml
@@ -8,13 +8,13 @@ on:
       - "installer/**"
       - "scripts/build-exe.ps1"
       - "scripts/build-installer.ps1"
-      - "scripts/verify-release-assets.ps1"
       - "scripts/verify-windows-installer.ps1"
       - "backend/launcher.py"
       - "backend/app/installer_updater.py"
       - "backend/app/updater.py"
       - "backend/app/routers/application_updates.py"
       - "backend/tests/test_installer_updater.py"
+      - "backend/tests/test_release_packaging_contract.py"
       - "backend/tests/test_windows_installer_contract.py"
   workflow_dispatch:
 
@@ -63,17 +63,22 @@ jobs:
         working-directory: backend
         run: python -m pytest tests/test_updater.py tests/test_installer_updater.py tests/test_packaging_contract.py tests/test_release_packaging_contract.py tests/test_windows_installer_contract.py
 
-      - name: Build portable bridge and installer
+      - name: Build Windows installer
         shell: cmd
         run: build-installer.bat
 
-      - name: Verify unsigned PR artifacts
+      - name: Verify unsigned installer artifact
+        shell: pwsh
+        run: ./scripts/verify-windows-installer.ps1 -ReleaseDir release
+
+      - name: Reject stale legacy release assets
         shell: pwsh
         run: |
-          $version = (Get-Content frontend/package.json -Raw | ConvertFrom-Json).version
-          ./scripts/verify-release-assets.ps1 -ReleaseDir release -ExpectedVersion $version
-          ./scripts/verify-windows-installer.ps1 -ReleaseDir release
-          ./scripts/smoke-test-release.ps1 -SkipBuild
+          $legacyAssets = @("release\Siming.exe", "release\update.json", "release\sha256.txt")
+          $found = @($legacyAssets | Where-Object { Test-Path -LiteralPath $_ })
+          if ($found.Count -gt 0) {
+            throw "Legacy Windows release assets must not be emitted: $($found -join ', ')"
+          }
 
       - name: Smoke install selectable-path package
         shell: pwsh

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,107 +1,160 @@
-# Windows 可执行程序打包
+# Windows 安装与发布
 
-## 生成 exe
+## 推荐分发方式
 
-在项目根目录运行：
+PC 正式版现在以 **Windows 安装包** 为主，构建入口：
 
 ```bat
-build-exe.bat
+build-installer.bat
 ```
 
-生成结果：
+生成的主要资产：
 
 ```text
+release\Siming-Setup.exe
+release\Siming-Setup.sha256
 release\Siming.exe
 release\update.json
 release\sha256.txt
 ```
 
-`Siming.exe` 是面向 Windows 10 x64 或更高版本的正式分发文件。Windows 7、Windows 8/8.1 和 32 位 Windows 不在支持范围内，不应将当前构建标记或分发为兼容这些系统。Android 使用独立的长期签名密钥构建；3.2.1 同时发布 APK。旧品牌数据目录仍然兼容，但旧 exe 名不再生成、不再上传。
+其中：
 
-## 给普通用户运行
+- `Siming-Setup.exe`：普通用户应下载的安装包。
+- `Siming-Setup.sha256`：安装包完整性校验文件。
+- `Siming.exe`：旧单文件版本的兼容升级桥，不再作为新用户的首选分发方式。
+- `update.json` / `sha256.txt`：继续服务旧单 EXE 更新器，使老版本仍能先升级到兼容桥，再迁移到安装版。
 
-**系统要求：Windows 10 x64 或更高版本。**
+**系统要求：Windows 10 x64 或更高版本。** Windows 7、Windows 8/8.1 和 32 位 Windows 不在支持范围内。
 
-新用户发送 `release\Siming.exe` 即可。用户双击后会：
+## 安装体验
 
-1. 自动启动本地后端服务。
-2. 自动打开浏览器页面。
-3. 使用本机数据目录保存数据库、密钥、模型和运行时配置。
+安装器使用 Inno Setup，默认安装到：
 
-默认数据目录：
+```text
+%LOCALAPPDATA%\Programs\Siming
+```
+
+安装向导会显示安装目录页，用户可以改到其他磁盘或目录。
+
+安装向导还会询问是否“在桌面创建快捷方式”。该选项默认勾选；用户可以主动取消。安装器同时创建开始菜单入口和卸载信息。
+
+安装器采用当前用户安装模式，不要求管理员权限即可安装到默认目录。用户若主动选择受保护的系统目录，则 Windows 权限规则仍然适用。
+
+程序数据与安装目录分离。默认数据目录仍然是：
 
 ```text
 %LOCALAPPDATA%\Siming
 ```
 
-如果用户已经用旧版产生过数据，新版启动时会自动检测：
+小说数据库、密钥、模型、日志、缓存与启动器配置不会随着覆盖安装而被删除。旧数据目录仍兼容：
 
 ```text
 %LOCALAPPDATA%\Moshu
 %LOCALAPPDATA%\NovelWritingAgent
 ```
 
-旧目录存在且新目录没有有效数据库时，司命会继续使用旧目录，避免用户丢数据。
+## 安装包内部结构
 
-## 重新指定数据目录
+安装包内部使用 PyInstaller `--onedir` 产物，而不是把全部运行时继续塞进一个自解压单文件：
 
-优先使用：
-
-```bat
-set SIMING_HOME=D:\SimingData
-release\Siming.exe
+```text
+<安装目录>\
+├── Siming.exe
+├── .siming-installed
+└── _internal\...
 ```
 
-旧变量 `MOSHU_HOME`、`NOVEL_AGENT_HOME` 仍然兼容。
+`.siming-installed` 是安装版标记，更新器用它区分“正式安装版”和“历史单 EXE 便携版”。
 
-## 打包机要求
+这样日常启动不再依赖 onefile 每次启动时的完整自解包流程；运行时文件也可以由安装器统一覆盖和维护。
 
-只有负责打包的电脑需要安装 Python、Node.js 和 npm。普通用户运行 `Siming.exe` 不需要安装这些工具。
+## 构建机要求
+
+负责打包的 Windows 机器需要：
+
+- Python（带 Tk，且可用于 PyInstaller）
+- Node.js / npm
+- Inno Setup（`ISCC.exe`）
+
+可以通过环境变量显式指定 Inno Setup 编译器：
+
+```powershell
+$env:SIMING_INNO_ISCC = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+.\scripts\build-installer.ps1
+```
+
+普通用户不需要安装 Python、Node.js 或 Inno Setup。
+
+如果只需要历史兼容的单 EXE，可以继续运行：
+
+```bat
+build-exe.bat
+```
+
+如果只需要检查 onedir 产物，可运行：
+
+```powershell
+.\scripts\build-exe.ps1 -OneDir
+```
 
 ## 自动更新
 
-桌面更新只接受同时满足以下条件的 `Siming.exe`：
+### 新安装版
 
-1. SHA-256 与 `update.json`、`sha256.txt` 完全一致。
+安装版优先查找 GitHub Release 中的：
+
+```text
+Siming-Setup.exe
+Siming-Setup.sha256
+```
+
+用户在设置页确认更新后，司命会：
+
+1. 下载新安装包到 `%LOCALAPPDATA%\Siming\updates`。
+2. 校验 SHA-256。
+3. 校验 Windows Authenticode 可信签名。
+4. 用户点击安装后，退出当前司命。
+5. 以静默模式运行新安装包，并强制使用当前安装目录。
+6. Inno Setup 覆盖程序文件并重新启动司命。
+
+升级时会沿用之前的安装目录和附加任务选择，因此用户第一次安装时如果取消了桌面快捷方式，后续更新不会擅自重新创建。
+
+### 从旧单 EXE 迁移
+
+旧客户端只认识 Release 中的 `Siming.exe`，所以发布阶段暂时继续保留它。
+
+旧版用户的迁移路径是：
+
+```text
+旧 Siming.exe
+  → 继续收到兼容 Siming.exe 更新
+  → 新更新器发现 Siming-Setup.exe
+  → 首次迁移时打开正常安装向导
+  → 用户选择安装位置和桌面快捷方式
+  → 后续版本使用安装包静默覆盖更新
+```
+
+首次迁移**不会**把用户原来随手放在“下载”目录里的 `Siming.exe` 所在目录当作安装目录。
+
+### 更新安全要求
+
+应用内更新只接受同时满足以下条件的 Windows 更新资产：
+
+1. SHA-256 与发布校验值一致。
 2. Windows Authenticode 签名可信。
 3. 签名包含可信时间戳。
 
-本地开发包可以不签名。正式自动更新包必须签名；没有证书时，只能显式使用 `-ManualDownloadOnly` 发布供用户主动下载并核对 SHA256 的手动安装包。签名必须在计算发布 SHA-256 **之前**完成，因为 Authenticode 会改变 exe 字节。
-
-默认更新仓库：
-
-```text
-teangtang1122/siming-ai
-```
-
-发布新版本时，在 GitHub Release 上传：
-
-```text
-Siming.exe
-sha256.txt
-update.json
-```
-
-`sha256.txt` 只包含：
-
-```text
-<sha256>  Siming.exe
-```
-
-更新器只下载 `Siming.exe`。Release 中不要上传旧 exe 名资产。
-
-### Windows 正式签名
-
-GitHub Actions 需要配置以下加密 Secrets：
+正式签名需要 GitHub Actions Secrets：
 
 ```text
 SIMING_WINDOWS_CODESIGN_PFX_BASE64
 SIMING_WINDOWS_CODESIGN_PASSWORD
 ```
 
-前者是受信任代码签名证书 PFX 的 Base64 内容，后者是 PFX 口令。证书、私钥和口令不得提交到仓库、构建日志或 Release 资产。
+证书、私钥和口令不得提交到仓库、日志或 Release 资产。
 
-本地发布机可在构建后运行：
+本地构建后可以分别签名单 EXE 兼容桥和安装包：
 
 ```powershell
 .\scripts\sign-windows-release.ps1 `
@@ -110,27 +163,67 @@ SIMING_WINDOWS_CODESIGN_PASSWORD
   -CertificatePassword $env:SIMING_CODESIGN_PASSWORD `
   -ExpectedVersion 3.2.1
 
+.\scripts\sign-windows-installer.ps1 `
+  -ReleaseDir release `
+  -CertificatePath C:\secure\siming-codesign.pfx `
+  -CertificatePassword $env:SIMING_CODESIGN_PASSWORD
+```
+
+然后验证：
+
+```powershell
 .\scripts\verify-release-assets.ps1 `
   -ReleaseDir release `
   -ExpectedVersion 3.2.1 `
   -RequireTrustedSignature
+
+.\scripts\verify-windows-installer.ps1 `
+  -ReleaseDir release `
+  -RequireTrustedSignature
 ```
 
-签名脚本会在可信时间戳校验通过后重新生成 `update.json` 与 `sha256.txt`。如果线上版本已经发布为未签名包，旧客户端会显示 `no_signature` 并停止安装；必须用签名后的同版本 exe 及重新计算的两个完整性文件一并替换，或者发布更高的签名版本。
+没有 Windows 代码签名证书时，只能发布供用户主动下载的手动安装资产；应用内更新器不会降低签名要求。
 
-没有 Windows 代码签名证书时，可发布仅供手动安装的 Windows 资产：
+## GitHub Release
 
-```powershell
-.\scripts\publish-github.ps1 -Tag v3.2.1 -SkipBuild -ManualDownloadOnly
+正式 Release 应包含：
+
+```text
+Siming-Setup.exe
+Siming-Setup.sha256
+Siming.exe
+update.json
+sha256.txt
+Siming.apk
+Siming-apk-sha256.txt
 ```
 
-该模式不会降低应用内更新器的签名要求，也不会包含 Android APK。
+GitHub Actions 的 Release Gate 会：
+
+1. 构建单 EXE 兼容桥。
+2. 构建 onedir 安装负载。
+3. 编译 `Siming-Setup.exe`。
+4. 执行后端、前端和发布契约测试。
+5. 对安装包执行无人值守安装冒烟测试。
+6. 有证书时分别签名 Windows 资产。
+7. 验证 SHA、签名、Android 资产和运行时版本。
+8. 全部通过后上传 Release。
+
+本地 `scripts\publish-github.ps1` 也会把安装包和安装包 SHA 一并纳入必需 Release 资产。
+
+## 重新指定数据目录
+
+程序数据目录和程序安装目录是两件不同的事。如果需要修改数据目录：
+
+```bat
+set SIMING_HOME=D:\SimingData
+```
+
+旧变量 `MOSHU_HOME`、`NOVEL_AGENT_HOME` 仍然兼容。
 
 ## Android APK
 
-3.2.1 恢复 Android 发布，并继续使用同一把长期保存的发布密钥。手动运行发布脚本时，必须显式使用 `-IncludeAndroid`，确保 APK 与校验文件一同上传。
-
-Android Release 必须使用同一把长期保存的发布密钥签名；丢失密钥后，已安装用户无法原位升级。密钥和口令不得写入仓库、构建日志或 Release 资产。
+Android 使用独立的长期签名密钥。手动发布时使用 `-IncludeAndroid`，确保 APK 与校验文件一同上传。
 
 本地构建机通过以下环境变量提供签名信息：
 
@@ -143,16 +236,14 @@ ANDROID_SDK_ROOT
 JAVA_HOME
 ```
 
-GitHub Actions 使用 `SIMING_ANDROID_KEYSTORE_BASE64` 保存同一密钥的 Base64 内容，并使用上述三个密码/别名 Secret；工作流只在临时目录还原密钥，构建结束后不保留该文件。
+GitHub Actions 使用 `SIMING_ANDROID_KEYSTORE_BASE64` 保存同一密钥的 Base64 内容。密钥与口令不得写入仓库、构建日志或 Release 资产。
 
-然后运行：
+构建和验证：
 
 ```powershell
 .\scripts\build-android-release.ps1
-.\scripts\verify-android-release.ps1 -ExpectedVersion 3.1.11
+.\scripts\verify-android-release.ps1 -ExpectedVersion 3.2.1
 ```
-
-验证脚本会检查 APK SHA-256、zip 对齐、签名证书、包名 `com.siming.mobile` 与版本号。GitHub Actions 使用同一发布密钥的加密 Secrets，不为每次构建临时生成新密钥。
 
 ## Gateway 容器
 
@@ -164,7 +255,7 @@ ghcr.io/teangtang1122/siming-ai-gateway:<major.minor>
 ghcr.io/teangtang1122/siming-ai-gateway:latest
 ```
 
-镜像必须包含 `linux/amd64` 与 `linux/arm64`，以 UID 10001 非 root 运行；`/data` 可写而 `/app` 不可写。发布前运行容器健康检查并验证 Docker Gateway 不暴露本地模型、CLI、MCP 与训练能力。
+镜像必须包含 `linux/amd64` 与 `linux/arm64`，以 UID 10001 非 root 运行；`/data` 可写而 `/app` 不可写。
 
 可用环境变量覆盖更新源：
 
@@ -178,24 +269,16 @@ set SIMING_DISABLE_UPDATE=1
 
 ## MCP Server
 
-打包后的 exe 包含 MCP Server 入口。推荐让程序自动检测和配置本机 Agent；手动排障时可以运行：
+安装后的 MCP 可直接指向安装目录中的：
+
+```text
+<安装目录>\Siming.exe
+```
+
+推荐让程序自动检测和配置本机 Agent；手动排障时可以运行：
 
 ```powershell
 powershell -NoProfile -File .\scripts\setup-external-agent-mcp.ps1
-```
-
-配置示例：
-
-```json
-{
-  "mcpServers": {
-    "siming": {
-      "command": "C:\\path\\to\\Siming.exe",
-      "args": ["--mcp-server", "--permission-pack", "project_management"],
-      "env": {}
-    }
-  }
-}
 ```
 
 如果从源码运行：
@@ -208,10 +291,10 @@ python scripts\moshu-mcp-server.py --permission-pack project_management
 
 ## Smoke Test
 
-打包后运行：
+单 EXE 运行时冒烟测试：
 
 ```powershell
 .\scripts\smoke-test-release.ps1
 ```
 
-测试会验证 `Siming.exe`、MCP 配置脚本、服务启动和核心 API。
+安装包本身另由 Release Gate 安装到临时目录，确认 `Siming.exe` 与 `.siming-installed` 均实际落盘后才允许发布。

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -2,28 +2,25 @@
 
 ## 推荐分发方式
 
-PC 正式版现在以 **Windows 安装包** 为主，构建入口：
+PC 正式版只发布 **Windows 安装包**，构建入口：
 
 ```bat
 build-installer.bat
 ```
 
-生成的主要资产：
+正式 Windows 发布资产：
 
 ```text
 release\Siming-Setup.exe
 release\Siming-Setup.sha256
-release\Siming.exe
-release\update.json
-release\sha256.txt
 ```
 
 其中：
 
-- `Siming-Setup.exe`：普通用户应下载的安装包。
+- `Siming-Setup.exe`：普通用户唯一应下载的 Windows 安装包。
 - `Siming-Setup.sha256`：安装包完整性校验文件。
-- `Siming.exe`：旧单文件版本的兼容升级桥，不再作为新用户的首选分发方式。
-- `update.json` / `sha256.txt`：继续服务旧单 EXE 更新器，使老版本仍能先升级到兼容桥，再迁移到安装版。
+
+`Siming.exe` 单文件包、`update.json` 和 `sha256.txt` 不再属于正式 Release 资产。`build-installer.bat` 会在打包前主动删除 `release` 目录中的这些旧产物，Release Gate 与本地发布脚本也会拒绝或清理同名旧资产，避免新用户误下载。
 
 **系统要求：Windows 10 x64 或更高版本。** Windows 7、Windows 8/8.1 和 32 位 Windows 不在支持范围内。
 
@@ -56,7 +53,7 @@ release\sha256.txt
 
 ## 安装包内部结构
 
-安装包内部使用 PyInstaller `--onedir` 产物，而不是把全部运行时继续塞进一个自解压单文件：
+安装包内部使用 PyInstaller `--onedir` 产物：
 
 ```text
 <安装目录>\
@@ -65,9 +62,9 @@ release\sha256.txt
 └── _internal\...
 ```
 
-`.siming-installed` 是安装版标记，更新器用它区分“正式安装版”和“历史单 EXE 便携版”。
+这里的 `Siming.exe` 是**安装目录里的程序主入口**，不是单独提供下载的单文件发行包。
 
-这样日常启动不再依赖 onefile 每次启动时的完整自解包流程；运行时文件也可以由安装器统一覆盖和维护。
+`.siming-installed` 是安装版标记，更新器用它识别正式安装布局。这样日常启动不再依赖 onefile 每次启动时的完整自解包流程，运行时文件也可以由安装器统一覆盖和维护。
 
 ## 构建机要求
 
@@ -86,11 +83,7 @@ $env:SIMING_INNO_ISCC = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 
 普通用户不需要安装 Python、Node.js 或 Inno Setup。
 
-如果只需要历史兼容的单 EXE，可以继续运行：
-
-```bat
-build-exe.bat
-```
+`build-exe.bat` 与 `scripts\build-exe.ps1` 仍保留给开发、排障和打包底层复用。它们不是正式 Windows Release 的发布入口；正式发布应始终使用 `build-installer.bat`。
 
 如果只需要检查 onedir 产物，可运行：
 
@@ -98,11 +91,9 @@ build-exe.bat
 .\scripts\build-exe.ps1 -OneDir
 ```
 
-## 自动更新
+## 应用内更新
 
-### 新安装版
-
-安装版优先查找 GitHub Release 中的：
+安装版查找 GitHub Release 中的：
 
 ```text
 Siming-Setup.exe
@@ -120,22 +111,7 @@ Siming-Setup.sha256
 
 升级时会沿用之前的安装目录和附加任务选择，因此用户第一次安装时如果取消了桌面快捷方式，后续更新不会擅自重新创建。
 
-### 从旧单 EXE 迁移
-
-旧客户端只认识 Release 中的 `Siming.exe`，所以发布阶段暂时继续保留它。
-
-旧版用户的迁移路径是：
-
-```text
-旧 Siming.exe
-  → 继续收到兼容 Siming.exe 更新
-  → 新更新器发现 Siming-Setup.exe
-  → 首次迁移时打开正常安装向导
-  → 用户选择安装位置和桌面快捷方式
-  → 后续版本使用安装包静默覆盖更新
-```
-
-首次迁移**不会**把用户原来随手放在“下载”目录里的 `Siming.exe` 所在目录当作安装目录。
+历史单 EXE 用户不再依赖 Release 中的兼容桥自动迁移。需要迁移时，直接通知用户下载当前版本 `Siming-Setup.exe` 并运行安装向导即可。程序数据仍位于独立的 `%LOCALAPPDATA%\Siming` 数据目录，因此安装版可以继续使用既有数据。
 
 ### 更新安全要求
 
@@ -154,15 +130,9 @@ SIMING_WINDOWS_CODESIGN_PASSWORD
 
 证书、私钥和口令不得提交到仓库、日志或 Release 资产。
 
-本地构建后可以分别签名单 EXE 兼容桥和安装包：
+本地安装包签名：
 
 ```powershell
-.\scripts\sign-windows-release.ps1 `
-  -ReleaseDir release `
-  -CertificatePath C:\secure\siming-codesign.pfx `
-  -CertificatePassword $env:SIMING_CODESIGN_PASSWORD `
-  -ExpectedVersion 3.2.1
-
 .\scripts\sign-windows-installer.ps1 `
   -ReleaseDir release `
   -CertificatePath C:\secure\siming-codesign.pfx `
@@ -172,11 +142,6 @@ SIMING_WINDOWS_CODESIGN_PASSWORD
 然后验证：
 
 ```powershell
-.\scripts\verify-release-assets.ps1 `
-  -ReleaseDir release `
-  -ExpectedVersion 3.2.1 `
-  -RequireTrustedSignature
-
 .\scripts\verify-windows-installer.ps1 `
   -ReleaseDir release `
   -RequireTrustedSignature
@@ -186,30 +151,35 @@ SIMING_WINDOWS_CODESIGN_PASSWORD
 
 ## GitHub Release
 
-正式 Release 应包含：
+正式 Release 的 Windows / Android 文件应为：
 
 ```text
 Siming-Setup.exe
 Siming-Setup.sha256
-Siming.exe
-update.json
-sha256.txt
 Siming.apk
 Siming-apk-sha256.txt
 ```
 
+以下 Windows 文件禁止作为新版本 Release 资产：
+
+```text
+Siming.exe
+update.json
+sha256.txt
+```
+
 GitHub Actions 的 Release Gate 会：
 
-1. 构建单 EXE 兼容桥。
-2. 构建 onedir 安装负载。
-3. 编译 `Siming-Setup.exe`。
+1. 构建 onedir 安装负载。
+2. 编译 `Siming-Setup.exe`。
+3. 确认没有遗留单 EXE Release 资产。
 4. 执行后端、前端和发布契约测试。
-5. 对安装包执行无人值守安装冒烟测试。
-6. 有证书时分别签名 Windows 资产。
-7. 验证 SHA、签名、Android 资产和运行时版本。
-8. 全部通过后上传 Release。
+5. 对安装包执行自定义安装目录的无人值守安装冒烟测试。
+6. 有证书时签名 Windows 安装包。
+7. 验证安装包 SHA、签名与 Android 资产。
+8. 全部通过后只上传安装包及 Android 资产。
 
-本地 `scripts\publish-github.ps1` 也会把安装包和安装包 SHA 一并纳入必需 Release 资产。
+本地 `scripts\publish-github.ps1` 使用相同的安装包唯一分发规则；如果目标 tag 已经存在旧 `Siming.exe`、`update.json` 或 `sha256.txt`，发布脚本会先删除它们。
 
 ## 重新指定数据目录
 
@@ -288,13 +258,3 @@ python scripts\moshu-mcp-server.py --permission-pack project_management
 ```
 
 入口脚本文件名暂时保留 `moshu-mcp-server.py`，用于兼容旧文档和旧配置；客户端里的服务器条目应使用 `siming`。
-
-## Smoke Test
-
-单 EXE 运行时冒烟测试：
-
-```powershell
-.\scripts\smoke-test-release.ps1
-```
-
-安装包本身另由 Release Gate 安装到临时目录，确认 `Siming.exe` 与 `.siming-installed` 均实际落盘后才允许发布。

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Siming is a free and open-source, local-first AI workspace for planning, writing
 [![Frontend CI](https://github.com/teangtang1122/siming-ai/actions/workflows/frontend-ci.yml/badge.svg?branch=main)](https://github.com/teangtang1122/siming-ai/actions/workflows/frontend-ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-3c7a57.svg)](LICENSE)
 
-[下载 Windows 版](https://github.com/teangtang1122/siming-ai/releases/latest/download/Siming.exe) · [Gitee 镜像下载（大陆网络较慢时备用）](https://gitee.com/teangtang13/siming-ai/releases) · [跨设备指南](docs/gateway-mobile.md) · [反馈问题](https://github.com/teangtang1122/siming-ai/issues/new/choose) · [版本记录](https://github.com/teangtang1122/siming-ai/releases)
+[下载 Windows 安装版](https://github.com/teangtang1122/siming-ai/releases/latest/download/Siming-Setup.exe) · [Gitee 镜像下载（大陆网络较慢时备用）](https://gitee.com/teangtang13/siming-ai/releases) · [跨设备指南](docs/gateway-mobile.md) · [反馈问题](https://github.com/teangtang1122/siming-ai/issues/new/choose) · [版本记录](https://github.com/teangtang1122/siming-ai/releases)
 
 > **系统要求：Windows 10 x64 或更高版本。Windows 7、Windows 8/8.1 以及 32 位 Windows 不在支持范围内。**
 
@@ -40,11 +40,11 @@ Siming is a free and open-source, local-first AI workspace for planning, writing
 
 ## 3 分钟开始
 
-### 1. 下载并启动
+### 1. 下载并安装
 
-在 Windows 10 x64 或更高版本上，从 [官方 GitHub Release](https://github.com/teangtang1122/siming-ai/releases/latest) 下载 `Siming.exe`，双击即可启动。普通使用者不需要安装 Python、Node.js，也不需要打开 CMD 或 PowerShell。Windows 7、Windows 8/8.1 和 32 位 Windows 不受支持。
+在 Windows 10 x64 或更高版本上，从 [官方 GitHub Release](https://github.com/teangtang1122/siming-ai/releases/latest) 下载 `Siming-Setup.exe` 并运行安装向导。你可以选择安装目录；安装器会询问是否创建桌面快捷方式，默认勾选。普通使用者不需要安装 Python、Node.js，也不需要打开 CMD 或 PowerShell。Windows 7、Windows 8/8.1 和 32 位 Windows 不受支持。
 
-首次启动会让你选择小说数据目录；不修改时使用 `%LOCALAPPDATA%\Siming`。旧版 `%LOCALAPPDATA%\Moshu` 和 `%LOCALAPPDATA%\NovelWritingAgent` 数据会兼容读取，不会被主动删除。
+默认程序目录为 `%LOCALAPPDATA%\Programs\Siming`。程序文件和小说数据相互独立：小说数据默认仍使用 `%LOCALAPPDATA%\Siming`，旧版 `%LOCALAPPDATA%\Moshu` 和 `%LOCALAPPDATA%\NovelWritingAgent` 数据会兼容读取，不会被主动删除。
 
 ### 2. 点击“准备 AI 并开始构思”
 
@@ -120,15 +120,15 @@ docker compose -f compose.gateway.yml up -d
 
 ## 下载与信任
 
-部分版本（包括 3.2.1）的 `Siming.exe` **尚未完成代码签名**，只提供用户主动下载、核对 SHA256 后手动安装。安全更新器会拒绝未签名包，不能用自动更新安装；具备可信 Windows 代码签名后才会恢复应用内更新。PyInstaller 打包的单文件 EXE 会在运行时解压内嵌 Python 组件、启动本地 Web 服务，并在用户授权时启动本机 CLI，因此未签名包还可能触发杀毒软件误报。
+Windows 正式下载资产现在以 `Siming-Setup.exe` 为主，`Siming.exe` 仅保留为历史单文件客户端的兼容升级桥。应用内安装包更新要求 SHA-256 与发布校验值一致，并通过可信 Windows Authenticode 签名校验；未签名发布只能供用户主动下载和手动安装，安全更新器不会静默放宽这一要求。
 
 为减少供应链风险：
 
 1. 只从 [`teangtang1122/siming-ai` 官方 Releases](https://github.com/teangtang1122/siming-ai/releases) 或 [Gitee 同步镜像 Releases](https://gitee.com/teangtang13/siming-ai/releases) 下载。
-2. 下载同一版本的 `sha256.txt`，用 `certutil -hashfile Siming.exe SHA256` 计算文件哈希并与其对照。
-3. 不要使用网盘、聊天群或第三方网站二次分发的 EXE。
+2. 下载同一版本的 `Siming-Setup.sha256`，用 `certutil -hashfile Siming-Setup.exe SHA256` 计算文件哈希并与其对照。
+3. 不要使用网盘、聊天群或第三方网站二次分发的安装包或 EXE。
 
-3.2.1 发行页提供 Windows 桌面三件套 `Siming.exe`、`update.json`、`sha256.txt`，以及 Android 的 `Siming.apk` 与 `Siming-apk-sha256.txt`。
+Windows Release 同时保留 `Siming-Setup.exe`、`Siming-Setup.sha256`、`Siming.exe`、`update.json`、`sha256.txt`；Android 提供 `Siming.apk` 与 `Siming-apk-sha256.txt`。旧单 EXE 用户收到兼容更新后，会由新更新器引导迁移到可选择安装目录的安装版；安装完成后的后续更新则使用已验证安装包覆盖原安装目录。
 
 ## 外部 Agent 与提示词投稿
 
@@ -145,7 +145,7 @@ docker compose -f compose.gateway.yml up -d
 
 ## 开发与贡献
 
-普通使用者只需要 `Siming.exe`。以下环境仅面向源码贡献者。
+普通使用者只需要 `Siming-Setup.exe`。以下环境仅面向源码贡献者。
 
 ```powershell
 # 后端
@@ -174,7 +174,7 @@ cd mobile\android
 .\gradlew.bat testDebugUnitTest lintDebug assembleDebug
 ```
 
-本地桌面打包使用 `.\build-exe.bat`；签名 APK 使用 `.\scripts\build-android-release.ps1`（签名凭据只通过环境变量提供）。提交代码、文档、可复现问题或者通过 GUI 生成的提示词投稿都很欢迎。
+本地桌面完整打包使用 `.\build-installer.bat`；只构建历史兼容单 EXE 可使用 `.\build-exe.bat`。签名 APK 使用 `.\scripts\build-android-release.ps1`（签名凭据只通过环境变量提供）。提交代码、文档、可复现问题或者通过 GUI 生成的提示词投稿都很欢迎。
 
 ## 路线图与许可证
 

--- a/backend/app/installer_updater.py
+++ b/backend/app/installer_updater.py
@@ -1,0 +1,398 @@
+"""Installer-aware Windows update flow.
+
+New installed builds prefer the signed Inno Setup package so a complete onedir
+runtime can be replaced safely.  The legacy Siming.exe release asset remains a
+compatibility bridge for older clients whose updater only understands the
+single-file executable.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from urllib import error as urllib_error
+
+from . import updater as legacy
+from .core.legacy_env import compatible_env_enabled, get_compatible_env
+from .version import APP_VERSION, DEFAULT_UPDATE_REPO
+
+INSTALLER_NAME = "Siming-Setup.exe"
+PORTABLE_NAME = legacy.EXE_NAME
+INSTALL_MARKER = ".siming-installed"
+INSTALLER_CHECKSUM_ASSET_NAMES = {
+    "siming-setup.sha256",
+    "siming-setup.exe.sha256",
+}
+
+
+def _valid_sha256(value: object) -> str:
+    text = str(value or "").strip().lower()
+    return text if re.fullmatch(r"[a-f0-9]{64}", text) else ""
+
+
+def _asset_sha256(asset: dict[str, Any], assets: list[dict[str, Any]]) -> str:
+    digest = str(asset.get("digest") or "").strip().lower()
+    if digest.startswith("sha256:"):
+        value = _valid_sha256(digest.removeprefix("sha256:"))
+        if value:
+            return value
+
+    checksum_asset = next(
+        (
+            candidate
+            for candidate in assets
+            if str(candidate.get("name") or "").lower()
+            in INSTALLER_CHECKSUM_ASSET_NAMES
+        ),
+        None,
+    )
+    if checksum_asset and checksum_asset.get("browser_download_url"):
+        try:
+            text = legacy._request(
+                str(checksum_asset["browser_download_url"]),
+                timeout=6,
+            ).decode("utf-8", errors="ignore")
+        except Exception:
+            return ""
+        match = re.search(r"\b([a-fA-F0-9]{64})\b", text)
+        return match.group(1).lower() if match else ""
+    return ""
+
+
+def _manifest_from_release_payload(
+    repo: str,
+    release: dict[str, Any],
+) -> dict[str, Any] | None:
+    tag = str(release.get("tag_name") or release.get("name") or "").strip()
+    version = tag.removeprefix("v")
+    raw_assets = release.get("assets")
+    assets = [asset for asset in raw_assets if isinstance(asset, dict)] if isinstance(raw_assets, list) else []
+    installer_asset = next(
+        (
+            asset
+            for asset in assets
+            if str(asset.get("name") or "").lower() == INSTALLER_NAME.lower()
+        ),
+        None,
+    )
+    if version and installer_asset and installer_asset.get("browser_download_url"):
+        return {
+            "version": version,
+            "download_url": str(installer_asset["browser_download_url"]),
+            "sha256": _asset_sha256(installer_asset, assets),
+            "source": release.get("html_url")
+            or f"https://github.com/{repo}/releases/latest",
+            "asset_name": INSTALLER_NAME,
+            "install_mode": "installer",
+        }
+
+    portable = legacy._manifest_from_release_payload(repo, release)
+    if not portable:
+        return None
+    return {
+        **portable,
+        "asset_name": PORTABLE_NAME,
+        "install_mode": "portable",
+    }
+
+
+def _release_has_update_asset(release: dict[str, Any]) -> bool:
+    assets = release.get("assets") if isinstance(release.get("assets"), list) else []
+    supported = {INSTALLER_NAME.lower(), PORTABLE_NAME.lower()}
+    return any(
+        isinstance(asset, dict)
+        and str(asset.get("name") or "").lower() in supported
+        for asset in assets
+    )
+
+
+def _manifest_from_github_release(
+    repo: str,
+    channel: str = "stable",
+) -> dict[str, Any] | None:
+    selected_channel = legacy.resolve_update_channel(channel)
+    if selected_channel == "stable":
+        release = legacy._request_json(
+            f"https://api.github.com/repos/{repo}/releases/latest"
+        )
+        return (
+            _manifest_from_release_payload(repo, release)
+            if isinstance(release, dict)
+            else None
+        )
+
+    releases = legacy._request_json(
+        f"https://api.github.com/repos/{repo}/releases?per_page=30"
+    )
+    if not isinstance(releases, list):
+        return None
+    eligible = [
+        release
+        for release in releases
+        if isinstance(release, dict)
+        and not release.get("draft")
+        and _release_has_update_asset(release)
+    ]
+    if not eligible:
+        return None
+    latest = eligible[0]
+    for candidate in eligible[1:]:
+        candidate_version = str(
+            candidate.get("tag_name") or candidate.get("name") or ""
+        )
+        latest_version = str(latest.get("tag_name") or latest.get("name") or "")
+        if legacy.is_newer_version(candidate_version, latest_version):
+            latest = candidate
+    return _manifest_from_release_payload(repo, latest)
+
+
+def _manifest_from_url(url: str) -> dict[str, Any] | None:
+    data = legacy._request_json(url)
+    if not isinstance(data, dict):
+        return None
+    version = str(data.get("version") or data.get("tag_name") or "").strip().removeprefix("v")
+    download_url = str(data.get("download_url") or data.get("url") or "").strip()
+    if not version or not download_url:
+        return None
+    asset_name = str(data.get("asset_name") or Path(download_url).name or "").strip()
+    install_mode = str(data.get("install_mode") or "").strip().lower()
+    if install_mode not in {"installer", "portable"}:
+        install_mode = (
+            "installer"
+            if asset_name.lower() == INSTALLER_NAME.lower()
+            else "portable"
+        )
+    return {
+        "version": version,
+        "download_url": download_url,
+        "sha256": _valid_sha256(data.get("sha256")),
+        "source": url,
+        "asset_name": asset_name or (INSTALLER_NAME if install_mode == "installer" else PORTABLE_NAME),
+        "install_mode": install_mode,
+    }
+
+
+def _running_install_root() -> Path | None:
+    if not getattr(sys, "frozen", False):
+        return None
+    current = Path(sys.executable).resolve()
+    if current.name.lower() != PORTABLE_NAME.lower():
+        return None
+    return current.parent if (current.parent / INSTALL_MARKER).is_file() else None
+
+
+def _portable_migration_needed(manifest: dict[str, Any]) -> bool:
+    if str(manifest.get("install_mode") or "") != "installer":
+        return False
+    if not getattr(sys, "frozen", False):
+        return False
+    current = Path(sys.executable).resolve()
+    if current.name.lower() != PORTABLE_NAME.lower():
+        return False
+    if (current.parent / INSTALL_MARKER).is_file():
+        return False
+    latest = str(manifest.get("version") or "").strip().removeprefix("v")
+    current_version = str(APP_VERSION).strip().removeprefix("v")
+    return latest == current_version
+
+
+def find_latest_update(channel: str | None = None) -> dict[str, Any] | None:
+    """Return the preferred installer update, falling back to legacy portable."""
+    if compatible_env_enabled("SIMING_DISABLE_UPDATE"):
+        return None
+    manifest_url = get_compatible_env("SIMING_UPDATE_MANIFEST_URL").strip()
+    repo = get_compatible_env(
+        "SIMING_UPDATE_REPO",
+        default=DEFAULT_UPDATE_REPO,
+    ).strip()
+    selected_channel = legacy.resolve_update_channel(channel)
+    try:
+        manifest = (
+            _manifest_from_url(manifest_url)
+            if manifest_url
+            else _manifest_from_github_release(repo, selected_channel)
+        )
+    except (
+        OSError,
+        urllib_error.URLError,
+        urllib_error.HTTPError,
+        json.JSONDecodeError,
+    ):
+        return None
+    if not manifest or not manifest.get("download_url"):
+        return None
+    manifest["channel"] = selected_channel
+    manifest["migration"] = _portable_migration_needed(manifest)
+    if legacy.is_newer_version(str(manifest.get("version") or "")):
+        return manifest
+    return manifest if manifest["migration"] else None
+
+
+def _public_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": str(manifest.get("version") or ""),
+        "channel": str(manifest.get("channel") or ""),
+        "source": str(manifest.get("source") or ""),
+        "download_url": str(manifest.get("download_url") or ""),
+        "asset_name": str(manifest.get("asset_name") or ""),
+        "install_mode": str(manifest.get("install_mode") or ""),
+        "migration": bool(manifest.get("migration")),
+        "sha256_available": bool(_valid_sha256(manifest.get("sha256"))),
+    }
+
+
+def get_update_status(
+    app_home: Path,
+    channel: str | None = None,
+) -> dict[str, Any]:
+    selected_channel = legacy.resolve_update_channel(channel)
+    manifest = find_latest_update(selected_channel)
+    staged = legacy._read_staged_update(app_home)
+    staged_payload = None
+    if staged:
+        staged_payload = {
+            "version": str(staged.get("version") or ""),
+            "sha256": str(staged.get("sha256") or ""),
+            "signature": staged.get("signature") if isinstance(staged.get("signature"), dict) else None,
+            "install_mode": str(staged.get("install_mode") or "portable"),
+            "migration": bool(staged.get("migration")),
+            "ready_to_install": False,
+        }
+        try:
+            legacy._validate_staged_update(app_home)
+            staged_payload["ready_to_install"] = True
+        except Exception as exc:
+            staged_payload["error"] = str(exc)
+    return {
+        "current_version": APP_VERSION,
+        "update_channel": selected_channel,
+        "update_available": bool(manifest),
+        "update": _public_manifest(manifest) if manifest else None,
+        "staged_update": staged_payload,
+        "automatic_updates": False,
+        "installed_layout": _running_install_root() is not None,
+    }
+
+
+def download_and_stage_update(
+    app_home: Path,
+    channel: str | None = None,
+) -> dict[str, Any]:
+    selected_channel = legacy.resolve_update_channel(channel)
+    manifest = find_latest_update(selected_channel)
+    if not manifest:
+        return get_update_status(app_home, selected_channel)
+    expected_sha256 = legacy._expected_sha256(manifest)
+    updates_dir = legacy._updates_dir(app_home)
+    updates_dir.mkdir(parents=True, exist_ok=True)
+    version = str(manifest["version"]).strip().removeprefix("v")
+    install_mode = str(manifest.get("install_mode") or "portable")
+    target_name = (
+        f"Siming-Setup-{version}.exe"
+        if install_mode == "installer"
+        else f"Siming-{version}.exe"
+    )
+    target = updates_dir / target_name
+    partial = target.with_name(target.name + ".part")
+    try:
+        if target.exists() and legacy._sha256_file(target) != expected_sha256:
+            target.unlink(missing_ok=True)
+        if not target.exists():
+            partial.unlink(missing_ok=True)
+            legacy._download_to_file(str(manifest["download_url"]), partial)
+            actual_sha256 = legacy._sha256_file(partial)
+            if actual_sha256 != expected_sha256:
+                raise RuntimeError(
+                    "Downloaded update checksum does not match the release manifest."
+                )
+            partial.replace(target)
+        actual_sha256 = legacy._sha256_file(target)
+        if actual_sha256 != expected_sha256:
+            raise RuntimeError(
+                "Downloaded update checksum does not match the release manifest."
+            )
+        signature = legacy._require_valid_signature(target)
+    except Exception:
+        partial.unlink(missing_ok=True)
+        target.unlink(missing_ok=True)
+        raise
+    staged = {
+        "version": version,
+        "path": str(target.resolve()),
+        "sha256": actual_sha256,
+        "source": str(manifest.get("source") or ""),
+        "asset_name": str(manifest.get("asset_name") or ""),
+        "install_mode": install_mode,
+        "migration": bool(manifest.get("migration")),
+        "signature": signature,
+    }
+    legacy._write_staged_update(app_home, staged)
+    result = get_update_status(app_home, selected_channel)
+    result["downloaded"] = True
+    result["staged_update"] = {
+        "version": version,
+        "sha256": actual_sha256,
+        "signature": signature,
+        "install_mode": install_mode,
+        "migration": bool(manifest.get("migration")),
+        "ready_to_install": True,
+    }
+    return result
+
+
+def schedule_staged_update_install(app_home: Path) -> dict[str, Any]:
+    staged = legacy._validate_staged_update(app_home)
+    if str(staged.get("install_mode") or "portable") != "installer":
+        return legacy.schedule_staged_update_install(app_home)
+
+    current_exe = legacy._current_packaged_executable()
+    installer = Path(str(staged["path"])).resolve()
+    installed_layout = (current_exe.parent / INSTALL_MARKER).is_file()
+    command = [str(installer)]
+    if installed_layout:
+        command.extend(
+            [
+                "/SP-",
+                "/VERYSILENT",
+                "/SUPPRESSMSGBOXES",
+                "/NORESTART",
+                f"/DIR={current_exe.parent}",
+            ]
+        )
+    else:
+        # First migration from the legacy one-file build remains interactive so
+        # the user can choose the install directory and desktop shortcut.
+        command.append("/SP-")
+
+    subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=str(installer.parent),
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    )
+    return {
+        "version": str(staged.get("version") or ""),
+        "signature": staged.get("signature"),
+        "install_mode": "installer",
+        "migration": not installed_layout,
+        "restart_scheduled": True,
+    }
+
+
+def apply_update_if_available(app_home: Path) -> bool:
+    return legacy.apply_update_if_available(app_home)
+
+
+__all__ = [
+    "apply_update_if_available",
+    "download_and_stage_update",
+    "find_latest_update",
+    "get_update_status",
+    "schedule_staged_update_install",
+]

--- a/backend/app/routers/application_updates.py
+++ b/backend/app/routers/application_updates.py
@@ -20,7 +20,7 @@ from ..services.application_settings import (
     normalize_gateway_allowed_hosts,
     save_launcher_settings,
 )
-from ..updater import (
+from ..installer_updater import (
     download_and_stage_update,
     get_update_status,
     schedule_staged_update_install,

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -1,4 +1,4 @@
 """Canonical application version and update defaults for release builds."""
 
-APP_VERSION = "3.2.1"
+APP_VERSION = "3.2.2"
 DEFAULT_UPDATE_REPO = "teangtang1122/siming-ai"

--- a/backend/tests/test_installer_updater.py
+++ b/backend/tests/test_installer_updater.py
@@ -1,0 +1,139 @@
+"""Tests for the installer-aware Windows update path."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app import installer_updater
+
+
+class InstallerUpdaterTestCase(unittest.TestCase):
+    @patch("app.installer_updater.legacy._request")
+    def test_release_prefers_setup_asset_and_its_checksum(self, mock_request):
+        mock_request.return_value = (b"b" * 64) + b"  Siming-Setup.exe\n"
+        release = {
+            "tag_name": "v9.9.9",
+            "html_url": "https://github.com/example/repo/releases/tag/v9.9.9",
+            "assets": [
+                {
+                    "name": "Siming.exe",
+                    "browser_download_url": "https://example.test/Siming.exe",
+                },
+                {
+                    "name": "Siming-Setup.exe",
+                    "browser_download_url": "https://example.test/Siming-Setup.exe",
+                },
+                {
+                    "name": "Siming-Setup.sha256",
+                    "browser_download_url": "https://example.test/Siming-Setup.sha256",
+                },
+            ],
+        }
+
+        manifest = installer_updater._manifest_from_release_payload(
+            "example/repo",
+            release,
+        )
+
+        self.assertIsNotNone(manifest)
+        self.assertEqual(manifest["asset_name"], "Siming-Setup.exe")
+        self.assertEqual(manifest["install_mode"], "installer")
+        self.assertEqual(
+            manifest["download_url"],
+            "https://example.test/Siming-Setup.exe",
+        )
+        self.assertEqual(manifest["sha256"], "b" * 64)
+
+    def test_release_falls_back_to_portable_bridge(self):
+        release = {
+            "tag_name": "v9.9.9",
+            "assets": [
+                {
+                    "name": "Siming.exe",
+                    "browser_download_url": "https://example.test/Siming.exe",
+                }
+            ],
+        }
+        with patch(
+            "app.installer_updater.legacy._manifest_from_release_payload",
+            return_value={
+                "version": "9.9.9",
+                "download_url": "https://example.test/Siming.exe",
+                "sha256": "a" * 64,
+                "source": "https://example.test/release",
+            },
+        ):
+            manifest = installer_updater._manifest_from_release_payload(
+                "example/repo",
+                release,
+            )
+
+        self.assertEqual(manifest["install_mode"], "portable")
+        self.assertEqual(manifest["asset_name"], "Siming.exe")
+
+    def test_installed_layout_runs_setup_silently_in_same_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            current = root / "Siming.exe"
+            current.write_bytes(b"app")
+            (root / installer_updater.INSTALL_MARKER).write_text("installed")
+            setup = root / "updates" / "Siming-Setup-9.9.9.exe"
+            setup.parent.mkdir()
+            setup.write_bytes(b"setup")
+            staged = {
+                "version": "9.9.9",
+                "path": str(setup),
+                "sha256": "a" * 64,
+                "signature": {"valid": True, "status": "Valid"},
+                "install_mode": "installer",
+            }
+            with patch(
+                "app.installer_updater.legacy._current_packaged_executable",
+                return_value=current,
+            ), patch(
+                "app.installer_updater.legacy._validate_staged_update",
+                return_value=staged,
+            ), patch("app.installer_updater.subprocess.Popen") as popen:
+                result = installer_updater.schedule_staged_update_install(root)
+
+            command = popen.call_args.args[0]
+            self.assertTrue(result["restart_scheduled"])
+            self.assertFalse(result["migration"])
+            self.assertIn("/VERYSILENT", command)
+            self.assertIn("/SUPPRESSMSGBOXES", command)
+            self.assertIn(f"/DIR={root}", command)
+
+    def test_legacy_portable_migration_keeps_installer_interactive(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            current = root / "Siming.exe"
+            current.write_bytes(b"app")
+            setup = root / "updates" / "Siming-Setup-9.9.9.exe"
+            setup.parent.mkdir()
+            setup.write_bytes(b"setup")
+            staged = {
+                "version": "9.9.9",
+                "path": str(setup),
+                "sha256": "a" * 64,
+                "signature": {"valid": True, "status": "Valid"},
+                "install_mode": "installer",
+            }
+            with patch(
+                "app.installer_updater.legacy._current_packaged_executable",
+                return_value=current,
+            ), patch(
+                "app.installer_updater.legacy._validate_staged_update",
+                return_value=staged,
+            ), patch("app.installer_updater.subprocess.Popen") as popen:
+                result = installer_updater.schedule_staged_update_install(root)
+
+            command = popen.call_args.args[0]
+            self.assertTrue(result["migration"])
+            self.assertIn("/SP-", command)
+            self.assertNotIn("/VERYSILENT", command)
+            self.assertFalse(any(part.startswith("/DIR=") for part in command))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_installer_updater.py
+++ b/backend/tests/test_installer_updater.py
@@ -10,16 +10,12 @@ from app import installer_updater
 
 class InstallerUpdaterTestCase(unittest.TestCase):
     @patch("app.installer_updater.legacy._request")
-    def test_release_prefers_setup_asset_and_its_checksum(self, mock_request):
+    def test_release_uses_setup_asset_and_its_checksum(self, mock_request):
         mock_request.return_value = (b"b" * 64) + b"  Siming-Setup.exe\n"
         release = {
             "tag_name": "v9.9.9",
             "html_url": "https://github.com/example/repo/releases/tag/v9.9.9",
             "assets": [
-                {
-                    "name": "Siming.exe",
-                    "browser_download_url": "https://example.test/Siming.exe",
-                },
                 {
                     "name": "Siming-Setup.exe",
                     "browser_download_url": "https://example.test/Siming-Setup.exe",
@@ -44,33 +40,6 @@ class InstallerUpdaterTestCase(unittest.TestCase):
             "https://example.test/Siming-Setup.exe",
         )
         self.assertEqual(manifest["sha256"], "b" * 64)
-
-    def test_release_falls_back_to_portable_bridge(self):
-        release = {
-            "tag_name": "v9.9.9",
-            "assets": [
-                {
-                    "name": "Siming.exe",
-                    "browser_download_url": "https://example.test/Siming.exe",
-                }
-            ],
-        }
-        with patch(
-            "app.installer_updater.legacy._manifest_from_release_payload",
-            return_value={
-                "version": "9.9.9",
-                "download_url": "https://example.test/Siming.exe",
-                "sha256": "a" * 64,
-                "source": "https://example.test/release",
-            },
-        ):
-            manifest = installer_updater._manifest_from_release_payload(
-                "example/repo",
-                release,
-            )
-
-        self.assertEqual(manifest["install_mode"], "portable")
-        self.assertEqual(manifest["asset_name"], "Siming.exe")
 
     def test_installed_layout_runs_setup_silently_in_same_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -104,7 +73,7 @@ class InstallerUpdaterTestCase(unittest.TestCase):
             self.assertIn("/SUPPRESSMSGBOXES", command)
             self.assertIn(f"/DIR={root}", command)
 
-    def test_legacy_portable_migration_keeps_installer_interactive(self):
+    def test_non_installed_packaged_layout_keeps_installer_interactive(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             current = root / "Siming.exe"

--- a/backend/tests/test_release_packaging_contract.py
+++ b/backend/tests/test_release_packaging_contract.py
@@ -95,10 +95,12 @@ def test_release_workflow_publishes_signed_android_assets():
     workflow = (ROOT / ".github" / "workflows" / "release-gate.yml").read_text(encoding="utf-8")
 
     assert "IncludeAndroid" in publisher
-    assert '$ReleaseAssets = @($ExePath, $ManifestPath, $ShaPath)' in publisher
+    assert '$ReleaseAssets = @($ExePath, $ManifestPath, $ShaPath, $InstallerPath, $InstallerShaPath)' in publisher
     assert "SIMING_ANDROID_KEYSTORE_BASE64" in workflow
     assert "Build signed Android APK" in workflow
     assert "verify-android-release.ps1" in workflow
+    assert "release/Siming-Setup.exe" in workflow
+    assert "release/Siming-Setup.sha256" in workflow
     assert "release/Siming.apk" in workflow
     assert "release/Siming-apk-sha256.txt" in workflow
 

--- a/backend/tests/test_release_packaging_contract.py
+++ b/backend/tests/test_release_packaging_contract.py
@@ -85,7 +85,7 @@ def test_windows_release_is_signed_before_integrity_manifests_are_published():
     assert "SIMING_WINDOWS_CODESIGN_PASSWORD" in workflow
     assert "manual-download-only" in workflow
     assert "github.event_name == 'push' && github.ref_type == 'tag'" in workflow
-    assert workflow.index("Sign Windows executable") < workflow.index(
+    assert workflow.index("Sign Windows distributions") < workflow.index(
         "Verify package assets and run smoke test"
     )
 

--- a/backend/tests/test_release_packaging_contract.py
+++ b/backend/tests/test_release_packaging_contract.py
@@ -42,6 +42,7 @@ def test_publisher_keeps_new_release_draft_until_all_assets_verify():
 
     assert '"--draft"' in script
     assert "MissingUploadedAssets" in script
+    assert "ForbiddenUploadedAssets" in script
     assert "--draft=false" in script
     assert "Assert-NativeSuccess \"upload release assets" in script
 
@@ -64,15 +65,14 @@ def test_android_release_verifies_version_code_and_trusted_certificate():
     assert "expectedVersionCode" in script
 
 
-def test_windows_release_is_signed_before_integrity_manifests_are_published():
-    signer = (ROOT / "scripts" / "sign-windows-release.ps1").read_text(encoding="utf-8")
-    verifier = (ROOT / "scripts" / "verify-release-assets.ps1").read_text(encoding="utf-8")
+def test_windows_release_publishes_only_the_installer_and_verifies_signature():
+    signer = (ROOT / "scripts" / "sign-windows-installer.ps1").read_text(encoding="utf-8")
+    verifier = (ROOT / "scripts" / "verify-windows-installer.ps1").read_text(encoding="utf-8")
     publisher = (ROOT / "scripts" / "publish-github.ps1").read_text(encoding="utf-8")
     workflow = (ROOT / ".github" / "workflows" / "release-gate.yml").read_text(encoding="utf-8")
 
     assert '"/fd", "SHA256"' in signer
     assert '"/tr", $TimestampUrl' in signer
-    assert "$Manifest.sha256 = $Sha256" in signer
     assert "$Signature.Status -ne \"Valid\"" in signer
     assert "TimeStamperCertificate" in signer
     assert "RequireTrustedSignature" in verifier
@@ -80,22 +80,21 @@ def test_windows_release_is_signed_before_integrity_manifests_are_published():
     assert "Get-AuthenticodeSignature" in verifier
     assert "-RequireTrustedSignature" in publisher
     assert "ManualDownloadOnly" in publisher
-    assert '"scripts\\smoke-test-release.ps1"' in publisher
+    assert '$ReleaseAssets = @($InstallerPath, $InstallerShaPath)' in publisher
+    assert '"Siming.exe", "update.json", "sha256.txt"' in publisher
     assert "SIMING_WINDOWS_CODESIGN_PFX_BASE64" in workflow
     assert "SIMING_WINDOWS_CODESIGN_PASSWORD" in workflow
     assert "manual-download-only" in workflow
     assert "github.event_name == 'push' && github.ref_type == 'tag'" in workflow
-    assert workflow.index("Sign Windows distributions") < workflow.index(
-        "Verify package assets and run smoke test"
-    )
+    assert workflow.index("Sign Windows installer") < workflow.index("Verify package assets")
 
 
-def test_release_workflow_publishes_signed_android_assets():
+def test_release_workflow_publishes_installer_and_signed_android_assets_only():
     publisher = (ROOT / "scripts" / "publish-github.ps1").read_text(encoding="utf-8")
     workflow = (ROOT / ".github" / "workflows" / "release-gate.yml").read_text(encoding="utf-8")
 
     assert "IncludeAndroid" in publisher
-    assert '$ReleaseAssets = @($ExePath, $ManifestPath, $ShaPath, $InstallerPath, $InstallerShaPath)' in publisher
+    assert '$ReleaseAssets = @($InstallerPath, $InstallerShaPath)' in publisher
     assert "SIMING_ANDROID_KEYSTORE_BASE64" in workflow
     assert "Build signed Android APK" in workflow
     assert "verify-android-release.ps1" in workflow
@@ -103,6 +102,10 @@ def test_release_workflow_publishes_signed_android_assets():
     assert "release/Siming-Setup.sha256" in workflow
     assert "release/Siming.apk" in workflow
     assert "release/Siming-apk-sha256.txt" in workflow
+    upload_block = workflow[workflow.index("Upload verified release assets"):workflow.index("Publish verified GitHub release")]
+    assert "release/Siming.exe" not in upload_block
+    assert "release/update.json" not in upload_block
+    assert "release/sha256.txt" not in upload_block
 
 
 def test_release_smoke_matches_runtime_to_update_manifest():

--- a/backend/tests/test_windows_installer_contract.py
+++ b/backend/tests/test_windows_installer_contract.py
@@ -20,14 +20,16 @@ def test_installer_allows_path_selection_and_defaults_desktop_shortcut_on():
     assert "UsePreviousTasks=yes" in script
 
 
-def test_installer_build_uses_onedir_payload_and_keeps_portable_bridge():
+def test_installer_build_uses_onedir_payload_without_portable_release_asset():
     script = (ROOT / "scripts" / "build-installer.ps1").read_text(encoding="utf-8")
 
     assert '"build-exe.ps1"' in script
     assert "-OneDir" in script
     assert '"Siming-Setup.exe"' in script
-    assert '"Siming.exe"' in script
     assert "ISCC.exe" in script
+    assert 'Remove-Item -LiteralPath (Join-Path $ReleaseDir $LegacyAsset)' in script
+    assert '@("Siming.exe", "update.json", "sha256.txt")' in script
+    assert "portable bridge" not in script.lower()
 
 
 def test_installer_update_is_signed_and_verified_separately():

--- a/backend/tests/test_windows_installer_contract.py
+++ b/backend/tests/test_windows_installer_contract.py
@@ -1,0 +1,43 @@
+"""Guardrails for the Windows installer distribution."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_installer_allows_path_selection_and_defaults_desktop_shortcut_on():
+    script = (ROOT / "installer" / "Siming.iss").read_text(encoding="utf-8")
+
+    assert "DisableDirPage=no" in script
+    assert "DefaultDirName={localappdata}\\Programs\\Siming" in script
+    assert 'Name: "desktopicon"' in script
+    desktop_task = next(
+        line for line in script.splitlines() if 'Name: "desktopicon"' in line
+    )
+    assert "unchecked" not in desktop_task.lower()
+    assert 'Tasks: desktopicon' in script
+    assert 'DestName: ".siming-installed"' in script
+    assert "UsePreviousAppDir=yes" in script
+    assert "UsePreviousTasks=yes" in script
+
+
+def test_installer_build_uses_onedir_payload_and_keeps_portable_bridge():
+    script = (ROOT / "scripts" / "build-installer.ps1").read_text(encoding="utf-8")
+
+    assert '"build-exe.ps1"' in script
+    assert "-OneDir" in script
+    assert '"Siming-Setup.exe"' in script
+    assert '"Siming.exe"' in script
+    assert "ISCC.exe" in script
+
+
+def test_installer_update_is_signed_and_verified_separately():
+    signer = (ROOT / "scripts" / "sign-windows-installer.ps1").read_text(encoding="utf-8")
+    verifier = (ROOT / "scripts" / "verify-windows-installer.ps1").read_text(encoding="utf-8")
+
+    assert '"/fd", "SHA256"' in signer
+    assert '"/tr", $TimestampUrl' in signer
+    assert "TimeStamperCertificate" in signer
+    assert "Siming-Setup.sha256" in signer
+    assert "RequireTrustedSignature" in verifier
+    assert "AllowUnsignedManualRelease" in verifier
+    assert "Get-AuthenticodeSignature" in verifier

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0"
+powershell.exe -NoProfile -File "%ROOT%scripts\build-installer.ps1" %*
+
+if errorlevel 1 (
+  set "BUILD_EXIT_CODE=%ERRORLEVEL%"
+  echo.
+  echo Installer packaging failed. See the message above.
+  if not defined CI pause
+  exit /b %BUILD_EXIT_CODE%
+)
+
+exit /b 0

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -3,13 +3,12 @@ setlocal
 
 set "ROOT=%~dp0"
 powershell.exe -NoProfile -File "%ROOT%scripts\build-installer.ps1" %*
-
-if errorlevel 1 (
-  set "BUILD_EXIT_CODE=%ERRORLEVEL%"
-  echo.
-  echo Installer packaging failed. See the message above.
-  if not defined CI pause
-  exit /b %BUILD_EXIT_CODE%
-)
+if errorlevel 1 goto :failed
 
 exit /b 0
+
+:failed
+echo.
+echo Installer packaging failed. See the message above.
+if not defined CI pause
+exit /b 1

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -98,13 +98,16 @@ AI/提示词变更：
 - [ ] README 顶部变更说明已同步。
 - [ ] 后端相关测试已运行。
 - [ ] 前端 `npm run build` 已运行。
-- [ ] 打包脚本已执行并生成 `Siming.exe`。
-- [ ] `update.json` 和 `sha256.txt` 已生成。
+- [ ] `build-installer.bat` 已执行并生成 `Siming-Setup.exe` 与 `Siming.exe` 兼容桥。
+- [ ] `Siming-Setup.sha256`、`update.json` 和 `sha256.txt` 已生成并与最终发布文件一致。
+- [ ] Windows 安装包已执行临时目录安装冒烟测试，确认 `Siming.exe`、`.siming-installed` 与卸载器实际落盘。
 - [ ] Release 说明包含重点变化、修复、兼容性、验证、已知问题。
 
 发布后：
 
-- [ ] 从 Release 下载包重新启动验证。
+- [ ] 从 Release 下载 `Siming-Setup.exe` 完成一次全新安装验证。
+- [ ] 从已安装旧版本执行一次应用内安装包升级验证。
+- [ ] 从旧单 `Siming.exe` 执行一次安装版迁移验证。
 - [ ] 验证新建作品、导入作品、建档、写作、保存。
 - [ ] 验证旧数据目录识别与迁移。
 - [ ] 验证至少一种 API 模型和一种本地/CLI 模型路径。

--- a/docs/release-notes-3.2.2.md
+++ b/docs/release-notes-3.2.2.md
@@ -1,0 +1,23 @@
+# 司命 3.2.2
+
+3.2.2 将 Windows 正式分发从历史单 EXE 改为标准安装包，重点改善安装路径、桌面快捷方式、卸载与后续安装版更新体验。
+
+## 主要改进
+
+- Windows 正式版改为 `Siming-Setup.exe` 安装包，安装时可以选择程序目录。
+- 桌面快捷方式作为安装选项提供并默认勾选，同时创建开始菜单入口和卸载信息。
+- 安装包内部使用 PyInstaller onedir 布局，减少单文件自解包带来的运行时路径复杂度，并为后续更新维护提供稳定安装目录。
+- 安装版更新优先下载并验证新的 `Siming-Setup.exe`，通过 SHA-256 与 Windows Authenticode 校验后在当前安装目录覆盖更新并重启。
+- 正式 Windows Release 不再提供独立 `Siming.exe`、`update.json` 和旧 `sha256.txt`，防止新用户误下载历史便携包。
+- Release Gate 增加真实 Windows 安装测试、禁止遗留单 EXE 资产检查和安装包 Artifact 保存。
+
+## 发布资产
+
+- `Siming-Setup.exe`：Windows 10 x64 或更高版本安装包。
+- `Siming-Setup.sha256`：Windows 安装包完整性校验文件。
+- `Siming.apk`、`Siming-apk-sha256.txt`：Android 客户端及校验文件。
+- Gateway 容器：随 Release 构建并发布 `amd64` 与 `arm64` 镜像。
+
+已有历史单 EXE 用户如需升级到安装版，请直接下载并运行 `Siming-Setup.exe`；程序数据与安装目录分离，既有作品和配置不会因为安装版覆盖而被删除。
+
+如果 Windows 代码签名证书未配置，本版本 Windows 安装包只能作为官方 Release 的手动下载资产；应用内安全更新仍不会放宽可信签名要求。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "siming-frontend",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/features/settings/UpdateSettingsCard.tsx
+++ b/frontend/src/features/settings/UpdateSettingsCard.tsx
@@ -17,6 +17,7 @@ import {
 const { Paragraph, Text } = Typography
 
 export type UpdateChannel = 'stable' | 'preview'
+type InstallMode = 'installer' | 'portable'
 
 interface UpdateSignature {
   valid: boolean
@@ -31,6 +32,9 @@ interface UpdateMetadata {
   source: string
   download_url: string
   sha256_available: boolean
+  asset_name?: string
+  install_mode?: InstallMode
+  migration?: boolean
 }
 
 interface StagedUpdate {
@@ -39,6 +43,8 @@ interface StagedUpdate {
   signature?: UpdateSignature | null
   ready_to_install: boolean
   error?: string
+  install_mode?: InstallMode
+  migration?: boolean
 }
 
 export interface UpdateStatus {
@@ -48,6 +54,7 @@ export interface UpdateStatus {
   update?: UpdateMetadata | null
   staged_update?: StagedUpdate | null
   automatic_updates: boolean
+  installed_layout?: boolean
   downloaded?: boolean
 }
 
@@ -80,6 +87,10 @@ export function UpdateSettingsCard({
   onDownload,
   onInstall,
 }: UpdateSettingsCardProps) {
+  const availableUpdate = updateStatus?.update
+  const migrationAvailable = Boolean(availableUpdate?.migration)
+  const stagedMigration = Boolean(updateStatus?.staged_update?.migration)
+
   return (
     <Card className="settings-card" title={<span><SafetyCertificateOutlined /> 安全更新</span>}>
       <Space direction="vertical" size={12} style={{ width: '100%' }}>
@@ -116,27 +127,27 @@ export function UpdateSettingsCard({
           <Button aria-label="检查更新" icon={<ReloadOutlined />} loading={checkingUpdate} onClick={onCheck}>
             检查更新
           </Button>
-          {updateStatus?.update_available && updateStatus.update && (
+          {updateStatus?.update_available && availableUpdate && (
             <Button
               type="primary"
               icon={<DownloadOutlined />}
-              aria-label={`下载并校验 ${updateStatus.update.version}`}
+              aria-label={migrationAvailable ? '下载并迁移到安装版' : `下载并校验 ${availableUpdate.version}`}
               loading={downloadingUpdate}
-              disabled={!updateStatus.update.sha256_available}
+              disabled={!availableUpdate.sha256_available}
               onClick={onDownload}
             >
-              下载并校验 {updateStatus.update.version}
+              {migrationAvailable ? '下载安装包并迁移' : `下载并校验 ${availableUpdate.version}`}
             </Button>
           )}
           {updateStatus?.staged_update?.ready_to_install && (
             <Button
               type="primary"
               icon={<SafetyCertificateOutlined />}
-              aria-label="安装并重启"
+              aria-label={stagedMigration ? '迁移到安装版' : '安装并重启'}
               loading={installingUpdate}
               onClick={onInstall}
             >
-              安装并重启
+              {stagedMigration ? '迁移到安装版' : '安装并重启'}
             </Button>
           )}
         </Space>
@@ -146,14 +157,21 @@ export function UpdateSettingsCard({
         {updateStatus && !updateStatus.update_available && !updateStatus.staged_update && (
           <Text type="secondary">已检查：当前版本 {updateStatus.current_version} 暂无可验证更新。</Text>
         )}
-        {updateStatus?.update_available && updateStatus.update && (
+        {updateStatus?.update_available && availableUpdate && (
           <Descriptions size="small" column={1} bordered>
-            <Descriptions.Item label="可用版本">{updateStatus.update.version}</Descriptions.Item>
+            <Descriptions.Item label={migrationAvailable ? '迁移目标' : '可用版本'}>
+              {migrationAvailable ? `司命 ${availableUpdate.version} 安装版` : availableUpdate.version}
+            </Descriptions.Item>
             <Descriptions.Item label="更新通道">
-              {updateStatus.update.channel === 'preview' ? '预览通道' : '稳定通道'}
+              {availableUpdate.channel === 'preview' ? '预览通道' : '稳定通道'}
+            </Descriptions.Item>
+            <Descriptions.Item label="更新方式">
+              {availableUpdate.install_mode === 'installer'
+                ? (migrationAvailable ? '首次迁移将打开 Windows 安装向导' : 'Windows 安装包覆盖更新')
+                : '单 EXE 兼容更新'}
             </Descriptions.Item>
             <Descriptions.Item label="SHA256">
-              {updateStatus.update.sha256_available ? '发布页提供，下载后会复核' : '发布页未提供，司命不会下载或安装'}
+              {availableUpdate.sha256_available ? '发布页提供，下载后会复核' : '发布页未提供，司命不会下载或安装'}
             </Descriptions.Item>
             <Descriptions.Item label="代码签名">下载后必须验证为可信签名</Descriptions.Item>
           </Descriptions>
@@ -162,9 +180,13 @@ export function UpdateSettingsCard({
           <Alert
             showIcon
             type={updateStatus.staged_update.ready_to_install ? 'success' : 'warning'}
-            message={updateStatus.staged_update.ready_to_install ? '更新已验证，可以由你确认安装' : '已下载的更新需要重新校验'}
+            message={updateStatus.staged_update.ready_to_install
+              ? (stagedMigration ? '安装包已验证，可以迁移到安装版' : '更新已验证，可以由你确认安装')
+              : '已下载的更新需要重新校验'}
             description={updateStatus.staged_update.ready_to_install
-              ? `版本 ${updateStatus.staged_update.version}，SHA256：${updateStatus.staged_update.sha256}`
+              ? (stagedMigration
+                ? `版本 ${updateStatus.staged_update.version}。点击“迁移到安装版”后会打开安装向导，你可以选择安装目录和桌面快捷方式。`
+                : `版本 ${updateStatus.staged_update.version}，SHA256：${updateStatus.staged_update.sha256}`)
               : updateStatus.staged_update.error || '请重新下载更新。'}
           />
         )}

--- a/installer/Siming.iss
+++ b/installer/Siming.iss
@@ -59,7 +59,8 @@ Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{a
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "启动 {#MyAppName}"; WorkingDir: "{app}"; Flags: nowait postinstall; Check: ShouldLaunchSiming
+Filename: "{app}\{#MyAppExeName}"; Description: "启动 {#MyAppName}"; WorkingDir: "{app}"; Flags: nowait postinstall skipifsilent; Check: ShouldLaunchSiming
+Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Flags: nowait skipifnotsilent; Check: ShouldLaunchSiming
 
 [Code]
 function ShouldLaunchSiming(): Boolean;

--- a/installer/Siming.iss
+++ b/installer/Siming.iss
@@ -1,0 +1,68 @@
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0-dev"
+#endif
+#ifndef SourceDir
+  #define SourceDir "..\release\Siming"
+#endif
+#ifndef OutputDir
+  #define OutputDir "..\release"
+#endif
+
+#define MyAppName "司命"
+#define MyAppExeName "Siming.exe"
+#define MyAppPublisher "teangtang1122"
+#define MyAppURL "https://github.com/teangtang1122/siming-ai"
+
+[Setup]
+AppId={{9D10D4A4-29F8-4F11-A88A-534A50F96D55}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases/latest
+DefaultDirName={localappdata}\Programs\Siming
+DefaultGroupName={#MyAppName}
+DisableDirPage=no
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+MinVersion=10.0.10240
+OutputDir={#OutputDir}
+OutputBaseFilename=Siming-Setup
+SetupIconFile=..\backend\Siming.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+UsePreviousAppDir=yes
+UsePreviousTasks=yes
+ChangesEnvironment=no
+
+[Languages]
+Name: "chinesesimp"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "在桌面创建快捷方式"; GroupDescription: "附加任务："
+
+[Files]
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "installed.marker"; DestDir: "{app}"; DestName: ".siming-installed"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "启动 {#MyAppName}"; WorkingDir: "{app}"; Flags: nowait postinstall; Check: ShouldLaunchSiming
+
+[Code]
+function ShouldLaunchSiming(): Boolean;
+begin
+  Result := CompareText(ExpandConstant('{param:SIMINGNOLAUNCH|0}'), '1') <> 0;
+end;

--- a/installer/Siming.iss
+++ b/installer/Siming.iss
@@ -44,11 +44,10 @@ UsePreviousTasks=yes
 ChangesEnvironment=no
 
 [Languages]
-Name: "chinesesimp"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
-Name: "desktopicon"; Description: "在桌面创建快捷方式"; GroupDescription: "附加任务："
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"
 
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -59,7 +58,7 @@ Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{a
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "启动 {#MyAppName}"; WorkingDir: "{app}"; Flags: nowait postinstall skipifsilent; Check: ShouldLaunchSiming
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; WorkingDir: "{app}"; Flags: nowait postinstall skipifsilent; Check: ShouldLaunchSiming
 Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Flags: nowait skipifnotsilent; Check: ShouldLaunchSiming
 
 [Code]

--- a/installer/installed.marker
+++ b/installer/installed.marker
@@ -1,0 +1,1 @@
+Siming Windows installer marker. Do not remove while the application is installed.

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.siming.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 30201
-        versionName = "3.2.1"
+        versionCode = 30202
+        versionName = "3.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -1,0 +1,118 @@
+param(
+  [string]$PipIndexUrl = "https://pypi.org/simple",
+  [string]$OutputDirectory = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Root = Split-Path -Parent $ScriptDir
+$BuildDir = Join-Path $Root ".build"
+$ReleaseDir = if ($OutputDirectory) {
+  [System.IO.Path]::GetFullPath($OutputDirectory)
+} else {
+  Join-Path $Root "release"
+}
+$PayloadDistDir = Join-Path $BuildDir "installer-payload"
+$InstallerScript = Join-Path $Root "installer\Siming.iss"
+$PortableExe = Join-Path $ReleaseDir "Siming.exe"
+$InstallerExe = Join-Path $ReleaseDir "Siming-Setup.exe"
+$InstallerShaPath = Join-Path $ReleaseDir "Siming-Setup.sha256"
+
+function Write-Step {
+  param([string]$Message)
+  Write-Host "[installer] $Message" -ForegroundColor Cyan
+}
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory=$true)][string]$FilePath,
+    [string[]]$Arguments = @()
+  )
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "Command failed ($LASTEXITCODE): $FilePath $($Arguments -join ' ')"
+  }
+}
+
+function Resolve-InnoCompiler {
+  if ($env:SIMING_INNO_ISCC) {
+    $Configured = [System.IO.Path]::GetFullPath($env:SIMING_INNO_ISCC)
+    if (-not (Test-Path -LiteralPath $Configured -PathType Leaf)) {
+      throw "SIMING_INNO_ISCC does not exist: $Configured"
+    }
+    return $Configured
+  }
+
+  $Command = Get-Command "ISCC.exe" -ErrorAction SilentlyContinue
+  if ($Command) { return $Command.Source }
+
+  $Roots = @(${env:ProgramFiles}, ${env:ProgramFiles(x86)}) |
+    Where-Object { $_ -and (Test-Path -LiteralPath $_ -PathType Container) }
+  foreach ($ProgramRoot in $Roots) {
+    $Candidates = @(
+      Get-ChildItem -LiteralPath $ProgramRoot -Directory -Filter "Inno Setup *" -ErrorAction SilentlyContinue |
+        ForEach-Object { Join-Path $_.FullName "ISCC.exe" } |
+        Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
+    )
+    if ($Candidates.Count -gt 0) {
+      return ($Candidates | Sort-Object -Descending | Select-Object -First 1)
+    }
+  }
+
+  throw "Inno Setup compiler ISCC.exe is required. Install Inno Setup or set SIMING_INNO_ISCC."
+}
+
+function Read-AppVersion {
+  $VersionFile = Join-Path $Root "backend\app\version.py"
+  $Match = Select-String -Path $VersionFile -Pattern 'APP_VERSION\s*=\s*["'']([^"'']+)' | Select-Object -First 1
+  if (-not $Match) { throw "Unable to read APP_VERSION from $VersionFile" }
+  return $Match.Matches.Groups[1].Value
+}
+
+Write-Step "Checking Inno Setup compiler..."
+$Iscc = Resolve-InnoCompiler
+$Version = Read-AppVersion
+Write-Step "Building Siming $Version portable bridge..."
+& (Join-Path $ScriptDir "build-exe.ps1") -PipIndexUrl $PipIndexUrl -OutputDirectory $ReleaseDir
+if ($LASTEXITCODE -ne 0) { throw "Portable bridge build failed." }
+
+Write-Step "Building installed onedir payload..."
+Remove-Item -LiteralPath $PayloadDistDir -Recurse -Force -ErrorAction SilentlyContinue
+& (Join-Path $ScriptDir "build-exe.ps1") -OneDir -PipIndexUrl $PipIndexUrl -OutputDirectory $PayloadDistDir
+if ($LASTEXITCODE -ne 0) { throw "Installed payload build failed." }
+
+$PayloadAppDir = Join-Path $PayloadDistDir "Siming"
+$PayloadExe = Join-Path $PayloadAppDir "Siming.exe"
+foreach ($RequiredPath in @($PortableExe, $PayloadExe, $InstallerScript)) {
+  if (-not (Test-Path -LiteralPath $RequiredPath)) {
+    throw "Installer input is missing: $RequiredPath"
+  }
+}
+
+Write-Step "Compiling selectable-path installer..."
+New-Item -ItemType Directory -Force -Path $ReleaseDir | Out-Null
+Remove-Item -LiteralPath $InstallerExe -Force -ErrorAction SilentlyContinue
+$IsccArgs = @(
+  "/DMyAppVersion=$Version",
+  "/DSourceDir=$PayloadAppDir",
+  "/DOutputDir=$ReleaseDir",
+  $InstallerScript
+)
+Invoke-Native $Iscc $IsccArgs
+
+if (-not (Test-Path -LiteralPath $InstallerExe -PathType Leaf)) {
+  throw "Inno Setup completed without producing $InstallerExe"
+}
+
+$InstallerSha = (Get-FileHash -Algorithm SHA256 -LiteralPath $InstallerExe).Hash.ToLowerInvariant()
+[System.IO.File]::WriteAllText(
+  $InstallerShaPath,
+  "$InstallerSha  Siming-Setup.exe" + [Environment]::NewLine,
+  [System.Text.UTF8Encoding]::new($false)
+)
+
+Write-Step "Done."
+Write-Host "Installer: $InstallerExe"
+Write-Host "Portable compatibility bridge: $PortableExe"
+Write-Host "Installer SHA256: $InstallerShaPath"

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -15,7 +15,6 @@ $ReleaseDir = if ($OutputDirectory) {
 }
 $PayloadDistDir = Join-Path $BuildDir "installer-payload"
 $InstallerScript = Join-Path $Root "installer\Siming.iss"
-$PortableExe = Join-Path $ReleaseDir "Siming.exe"
 $InstallerExe = Join-Path $ReleaseDir "Siming-Setup.exe"
 $InstallerShaPath = Join-Path $ReleaseDir "Siming-Setup.sha256"
 
@@ -73,25 +72,27 @@ function Read-AppVersion {
 Write-Step "Checking Inno Setup compiler..."
 $Iscc = Resolve-InnoCompiler
 $Version = Read-AppVersion
-Write-Step "Building Siming $Version portable bridge..."
-& (Join-Path $ScriptDir "build-exe.ps1") -PipIndexUrl $PipIndexUrl -OutputDirectory $ReleaseDir
-if ($LASTEXITCODE -ne 0) { throw "Portable bridge build failed." }
 
-Write-Step "Building installed onedir payload..."
+Write-Step "Removing stale legacy release assets..."
+New-Item -ItemType Directory -Force -Path $ReleaseDir | Out-Null
+foreach ($LegacyAsset in @("Siming.exe", "update.json", "sha256.txt")) {
+  Remove-Item -LiteralPath (Join-Path $ReleaseDir $LegacyAsset) -Force -ErrorAction SilentlyContinue
+}
+
+Write-Step "Building installed onedir payload for Siming $Version..."
 Remove-Item -LiteralPath $PayloadDistDir -Recurse -Force -ErrorAction SilentlyContinue
 & (Join-Path $ScriptDir "build-exe.ps1") -OneDir -PipIndexUrl $PipIndexUrl -OutputDirectory $PayloadDistDir
 if ($LASTEXITCODE -ne 0) { throw "Installed payload build failed." }
 
 $PayloadAppDir = Join-Path $PayloadDistDir "Siming"
 $PayloadExe = Join-Path $PayloadAppDir "Siming.exe"
-foreach ($RequiredPath in @($PortableExe, $PayloadExe, $InstallerScript)) {
+foreach ($RequiredPath in @($PayloadExe, $InstallerScript)) {
   if (-not (Test-Path -LiteralPath $RequiredPath)) {
     throw "Installer input is missing: $RequiredPath"
   }
 }
 
 Write-Step "Compiling selectable-path installer..."
-New-Item -ItemType Directory -Force -Path $ReleaseDir | Out-Null
 Remove-Item -LiteralPath $InstallerExe -Force -ErrorAction SilentlyContinue
 $IsccArgs = @(
   "/DMyAppVersion=$Version",
@@ -114,5 +115,4 @@ $InstallerSha = (Get-FileHash -Algorithm SHA256 -LiteralPath $InstallerExe).Hash
 
 Write-Step "Done."
 Write-Host "Installer: $InstallerExe"
-Write-Host "Portable compatibility bridge: $PortableExe"
 Write-Host "Installer SHA256: $InstallerShaPath"

--- a/scripts/publish-github.ps1
+++ b/scripts/publish-github.ps1
@@ -18,9 +18,11 @@ $AppName = "Siming"
 $ExePath = Join-Path $Root "release\$AppName.exe"
 $ManifestPath = Join-Path $Root "release\update.json"
 $ShaPath = Join-Path $Root "release\sha256.txt"
+$InstallerPath = Join-Path $Root "release\$AppName-Setup.exe"
+$InstallerShaPath = Join-Path $Root "release\$AppName-Setup.sha256"
 $ApkPath = Join-Path $Root "release\$AppName.apk"
 $ApkShaPath = Join-Path $Root "release\$AppName-apk-sha256.txt"
-$ReleaseAssets = @($ExePath, $ManifestPath, $ShaPath)
+$ReleaseAssets = @($ExePath, $ManifestPath, $ShaPath, $InstallerPath, $InstallerShaPath)
 if ($IncludeAndroid) {
   $ReleaseAssets += @($ApkPath, $ApkShaPath)
 }
@@ -84,7 +86,7 @@ try {
   }
 
   if (-not $SkipBuild -and -not $DryRun) {
-    & (Join-Path $Root "scripts\build-exe.ps1")
+    & (Join-Path $Root "scripts\build-installer.ps1")
   }
 
   $MissingReleaseAssets = @($ReleaseAssets | Where-Object { -not (Test-Path -LiteralPath $_) })
@@ -123,8 +125,10 @@ try {
       [System.IO.File]::WriteAllText($ShaPath, ($shaLines -join [Environment]::NewLine) + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
       if ($ManualDownloadOnly) {
         & (Join-Path $Root "scripts\verify-release-assets.ps1") -ReleaseDir (Split-Path -Parent $ExePath) -AppName $AppName -ExpectedVersion $version -AllowUnsignedManualRelease
+        & (Join-Path $Root "scripts\verify-windows-installer.ps1") -ReleaseDir (Split-Path -Parent $InstallerPath) -AllowUnsignedManualRelease
       } else {
         & (Join-Path $Root "scripts\verify-release-assets.ps1") -ReleaseDir (Split-Path -Parent $ExePath) -AppName $AppName -ExpectedVersion $version -RequireTrustedSignature
+        & (Join-Path $Root "scripts\verify-windows-installer.ps1") -ReleaseDir (Split-Path -Parent $InstallerPath) -RequireTrustedSignature
       }
       if ($IncludeAndroid) {
         & (Join-Path $Root "scripts\verify-android-release.ps1") -ReleaseDir (Split-Path -Parent $ApkPath) -ExpectedVersion $version

--- a/scripts/publish-github.ps1
+++ b/scripts/publish-github.ps1
@@ -15,17 +15,15 @@ $ErrorActionPreference = "Stop"
 
 $Root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
 $AppName = "Siming"
-$ExePath = Join-Path $Root "release\$AppName.exe"
-$ManifestPath = Join-Path $Root "release\update.json"
-$ShaPath = Join-Path $Root "release\sha256.txt"
 $InstallerPath = Join-Path $Root "release\$AppName-Setup.exe"
 $InstallerShaPath = Join-Path $Root "release\$AppName-Setup.sha256"
 $ApkPath = Join-Path $Root "release\$AppName.apk"
 $ApkShaPath = Join-Path $Root "release\$AppName-apk-sha256.txt"
-$ReleaseAssets = @($ExePath, $ManifestPath, $ShaPath, $InstallerPath, $InstallerShaPath)
+$ReleaseAssets = @($InstallerPath, $InstallerShaPath)
 if ($IncludeAndroid) {
   $ReleaseAssets += @($ApkPath, $ApkShaPath)
 }
+$ForbiddenWindowsAssets = @("Siming.exe", "update.json", "sha256.txt", "Moshu.exe", "NovelWritingAgent.exe")
 
 function Require-Command {
   param([string]$Name, [string]$Hint)
@@ -99,41 +97,15 @@ try {
     }
   }
 
-  if (Test-Path $ExePath) {
-    $sha = (Get-FileHash -Algorithm SHA256 -LiteralPath $ExePath).Hash.ToLowerInvariant()
-    $version = $Tag.TrimStart("v")
-    $isPrerelease = $version.Contains("-")
-    $updateChannel = if ($isPrerelease) { "preview" } else { "stable" }
-    $downloadUrl = if ($isPrerelease) {
-      "https://github.com/$Repo/releases/download/$Tag/$AppName.exe"
+  if (-not $DryRun) {
+    if ($ManualDownloadOnly) {
+      & (Join-Path $Root "scripts\verify-windows-installer.ps1") -ReleaseDir (Split-Path -Parent $InstallerPath) -AllowUnsignedManualRelease
     } else {
-      "https://github.com/$Repo/releases/latest/download/$AppName.exe"
+      & (Join-Path $Root "scripts\verify-windows-installer.ps1") -ReleaseDir (Split-Path -Parent $InstallerPath) -RequireTrustedSignature
     }
-    $manifest = [ordered]@{
-      version = $version
-      channel = $updateChannel
-      download_url = $downloadUrl
-      sha256 = $sha
-      repo = $Repo
-    } | ConvertTo-Json -Depth 3
-    $shaLines = @("$sha  $AppName.exe")
-    if ($DryRun) {
-      Write-Host "[dry-run] SHA256 would be written: $sha" -ForegroundColor Cyan
-      Write-Host "[dry-run] Manifest version would be written: $version" -ForegroundColor Cyan
-    } else {
-      [System.IO.File]::WriteAllText($ManifestPath, $manifest + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
-      [System.IO.File]::WriteAllText($ShaPath, ($shaLines -join [Environment]::NewLine) + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
-      if ($ManualDownloadOnly) {
-        & (Join-Path $Root "scripts\verify-release-assets.ps1") -ReleaseDir (Split-Path -Parent $ExePath) -AppName $AppName -ExpectedVersion $version -AllowUnsignedManualRelease
-        & (Join-Path $Root "scripts\verify-windows-installer.ps1") -ReleaseDir (Split-Path -Parent $InstallerPath) -AllowUnsignedManualRelease
-      } else {
-        & (Join-Path $Root "scripts\verify-release-assets.ps1") -ReleaseDir (Split-Path -Parent $ExePath) -AppName $AppName -ExpectedVersion $version -RequireTrustedSignature
-        & (Join-Path $Root "scripts\verify-windows-installer.ps1") -ReleaseDir (Split-Path -Parent $InstallerPath) -RequireTrustedSignature
-      }
-      if ($IncludeAndroid) {
-        & (Join-Path $Root "scripts\verify-android-release.ps1") -ReleaseDir (Split-Path -Parent $ApkPath) -ExpectedVersion $version
-      }
-      & (Join-Path $Root "scripts\smoke-test-release.ps1") -SkipBuild
+    if ($IncludeAndroid) {
+      $version = $Tag.TrimStart("v")
+      & (Join-Path $Root "scripts\verify-android-release.ps1") -ReleaseDir (Split-Path -Parent $ApkPath) -ExpectedVersion $version
     }
   }
 
@@ -170,6 +142,7 @@ try {
     foreach ($Asset in $ReleaseAssets) {
       Write-Host "  $Asset exists=$(Test-Path -LiteralPath $Asset)"
     }
+    Write-Host "[dry-run] Legacy Windows assets are forbidden in Releases: $($ForbiddenWindowsAssets -join ', ')" -ForegroundColor Cyan
     return
   }
 
@@ -178,6 +151,7 @@ try {
   if (-not $CurrentBranch) {
     throw "Release publishing requires a named branch, not detached HEAD."
   }
+
   $PreviousErrorActionPreference = $ErrorActionPreference
   $ErrorActionPreference = "Continue"
   $ExistingTagCommit = git rev-list -n 1 $Tag 2>$null
@@ -188,6 +162,7 @@ try {
   } else {
     $ExistingTagCommit = ($ExistingTagCommit | Select-Object -First 1).Trim()
   }
+
   $HeadCommit = (git rev-parse HEAD).Trim()
   Assert-NativeSuccess "git rev-parse HEAD"
   if ($ExistingTagCommit -and $ExistingTagCommit -ne $HeadCommit) {
@@ -197,6 +172,7 @@ try {
     git tag -a $Tag -m "Siming $Tag"
     Assert-NativeSuccess "git tag $Tag"
   }
+
   git push -u origin $CurrentBranch
   Assert-NativeSuccess "git push branch $CurrentBranch"
   git push origin $Tag
@@ -207,6 +183,7 @@ try {
   gh release view $Tag -R $Repo *>$null
   $ReleaseExists = $LASTEXITCODE -eq 0
   $ErrorActionPreference = $PreviousErrorActionPreference
+
   $ReleaseWasDraft = $false
   if (-not $ReleaseExists) {
     $Version = $Tag.TrimStart("v")
@@ -237,15 +214,17 @@ try {
       Assert-NativeSuccess "mark release $Tag as prerelease"
     }
   }
+
   $ExistingRelease = gh release view $Tag -R $Repo --json assets | ConvertFrom-Json
   Assert-NativeSuccess "read release assets for $Tag"
   $ExistingAssetNames = @($ExistingRelease.assets | ForEach-Object { $_.name })
-  foreach ($LegacyAssetName in @("Moshu.exe", "NovelWritingAgent.exe")) {
+  foreach ($LegacyAssetName in $ForbiddenWindowsAssets) {
     if ($ExistingAssetNames -contains $LegacyAssetName) {
       gh release delete-asset $Tag $LegacyAssetName -R $Repo -y
       Assert-NativeSuccess "delete legacy release asset $LegacyAssetName"
     }
   }
+
   gh release upload $Tag -R $Repo @ReleaseAssets --clobber
   Assert-NativeSuccess "upload release assets for $Tag"
 
@@ -256,6 +235,10 @@ try {
   $MissingUploadedAssets = @($ExpectedAssetNames | Where-Object { $_ -notin $UploadedAssetNames })
   if ($MissingUploadedAssets.Count -gt 0) {
     throw "Release remains unpublished because uploaded assets are incomplete: $($MissingUploadedAssets -join ', ')."
+  }
+  $ForbiddenUploadedAssets = @($ForbiddenWindowsAssets | Where-Object { $_ -in $UploadedAssetNames })
+  if ($ForbiddenUploadedAssets.Count -gt 0) {
+    throw "Release remains unpublished because legacy Windows assets are still present: $($ForbiddenUploadedAssets -join ', ')."
   }
 
   if ($ReleaseWasDraft) {

--- a/scripts/sign-windows-installer.ps1
+++ b/scripts/sign-windows-installer.ps1
@@ -1,0 +1,85 @@
+param(
+  [string]$ReleaseDir = "release",
+  [Parameter(Mandatory = $true)]
+  [string]$CertificatePath,
+  [Parameter(Mandatory = $true)]
+  [AllowEmptyString()]
+  [string]$CertificatePassword,
+  [string]$TimestampUrl = "http://timestamp.digicert.com"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-SignTool {
+  if ($env:SIMING_SIGNTOOL_PATH) {
+    $ConfiguredPath = [System.IO.Path]::GetFullPath($env:SIMING_SIGNTOOL_PATH)
+    if (-not (Test-Path -LiteralPath $ConfiguredPath -PathType Leaf)) {
+      throw "SIMING_SIGNTOOL_PATH does not exist: $ConfiguredPath"
+    }
+    return $ConfiguredPath
+  }
+
+  $Command = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+  if ($Command) { return $Command.Source }
+
+  $WindowsKitsRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+  if (Test-Path -LiteralPath $WindowsKitsRoot -PathType Container) {
+    $Candidates = @(
+      Get-ChildItem -LiteralPath $WindowsKitsRoot -Filter "signtool.exe" -File -Recurse |
+        Where-Object { $_.FullName -match "\\x64\\signtool\.exe$" } |
+        Sort-Object FullName -Descending
+    )
+    if ($Candidates.Count -gt 0) { return $Candidates[0].FullName }
+  }
+
+  throw "Windows SDK signtool.exe is required to sign Siming-Setup.exe."
+}
+
+$ResolvedReleaseDir = [System.IO.Path]::GetFullPath($ReleaseDir)
+$InstallerPath = Join-Path $ResolvedReleaseDir "Siming-Setup.exe"
+$ShaPath = Join-Path $ResolvedReleaseDir "Siming-Setup.sha256"
+$ResolvedCertificatePath = [System.IO.Path]::GetFullPath($CertificatePath)
+foreach ($RequiredPath in @($InstallerPath, $ResolvedCertificatePath)) {
+  if (-not (Test-Path -LiteralPath $RequiredPath -PathType Leaf)) {
+    throw "Windows installer signing input is missing: $RequiredPath"
+  }
+}
+
+$SignTool = Resolve-SignTool
+$SignArguments = @(
+  "sign",
+  "/fd", "SHA256",
+  "/td", "SHA256",
+  "/tr", $TimestampUrl,
+  "/f", $ResolvedCertificatePath
+)
+if ($CertificatePassword) {
+  $SignArguments += @("/p", $CertificatePassword)
+}
+$SignArguments += $InstallerPath
+
+Write-Host "Signing Siming-Setup.exe with a trusted, timestamped Authenticode signature..."
+& $SignTool @SignArguments
+if ($LASTEXITCODE -ne 0) {
+  throw "signtool.exe failed with exit code $LASTEXITCODE."
+}
+
+$Signature = Get-AuthenticodeSignature -FilePath $InstallerPath
+if ($Signature.Status -ne "Valid" -or -not $Signature.SignerCertificate) {
+  throw "Signed installer is not trusted: status=$($Signature.Status) message=$($Signature.StatusMessage)"
+}
+if (-not $Signature.TimeStamperCertificate) {
+  throw "Signed installer has no trusted timestamp."
+}
+
+$Sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $InstallerPath).Hash.ToLowerInvariant()
+[System.IO.File]::WriteAllText(
+  $ShaPath,
+  "$Sha256  Siming-Setup.exe" + [Environment]::NewLine,
+  [System.Text.UTF8Encoding]::new($false)
+)
+
+Write-Host "Windows installer signed and checksum refreshed." -ForegroundColor Green
+Write-Host "Signer: $($Signature.SignerCertificate.Subject)"
+Write-Host "Thumbprint: $($Signature.SignerCertificate.Thumbprint)"
+Write-Host "SHA256: $Sha256"

--- a/scripts/verify-windows-installer.ps1
+++ b/scripts/verify-windows-installer.ps1
@@ -1,0 +1,43 @@
+param(
+  [string]$ReleaseDir = "release",
+  [switch]$RequireTrustedSignature,
+  [switch]$AllowUnsignedManualRelease
+)
+
+$ErrorActionPreference = "Stop"
+
+$InstallerPath = Join-Path $ReleaseDir "Siming-Setup.exe"
+$ShaPath = Join-Path $ReleaseDir "Siming-Setup.sha256"
+foreach ($RequiredPath in @($InstallerPath, $ShaPath)) {
+  if (-not (Test-Path -LiteralPath $RequiredPath -PathType Leaf)) {
+    throw "Windows installer asset is missing: $RequiredPath"
+  }
+}
+
+$ActualSha = (Get-FileHash -Algorithm SHA256 -LiteralPath $InstallerPath).Hash.ToLowerInvariant()
+$ShaTokens = ((Get-Content -LiteralPath $ShaPath -TotalCount 1).Trim() -split '\s+')
+if ($ShaTokens.Count -lt 2 -or $ShaTokens[1] -ne "Siming-Setup.exe") {
+  throw "Siming-Setup.sha256 must contain the Siming-Setup.exe file name."
+}
+if ($ShaTokens[0].ToLowerInvariant() -ne $ActualSha) {
+  throw "Siming-Setup.sha256 does not match Siming-Setup.exe."
+}
+if ($RequireTrustedSignature -and $AllowUnsignedManualRelease) {
+  throw "Choose either -RequireTrustedSignature or -AllowUnsignedManualRelease, not both."
+}
+
+if ($RequireTrustedSignature -or $AllowUnsignedManualRelease) {
+  $Signature = Get-AuthenticodeSignature -FilePath $InstallerPath
+  if ($Signature.Status -eq "Valid" -and $Signature.SignerCertificate) {
+    if (-not $Signature.TimeStamperCertificate) {
+      throw "Windows installer Authenticode signature has no trusted timestamp."
+    }
+    Write-Host "Trusted installer signer: $($Signature.SignerCertificate.Subject) thumbprint=$($Signature.SignerCertificate.Thumbprint)" -ForegroundColor Green
+  } elseif ($AllowUnsignedManualRelease -and $Signature.Status -eq "NotSigned") {
+    Write-Warning "Siming-Setup.exe is unsigned and may only be distributed for explicit manual installation. The in-app updater will reject it."
+  } else {
+    throw "Windows installer Authenticode signature is not trusted: status=$($Signature.Status) message=$($Signature.StatusMessage)"
+  }
+}
+
+Write-Host "Windows installer verified: Siming-Setup.exe sha256=$ActualSha" -ForegroundColor Green


### PR DESCRIPTION
## 改动

- 新增 Inno Setup Windows 安装包，默认安装到 `%LOCALAPPDATA%\Programs\Siming`，安装目录可由用户修改。
- 安装时询问是否创建桌面快捷方式，默认勾选，并记录用户选择供后续覆盖安装沿用。
- 安装包内部使用 PyInstaller onedir 负载，并通过 `.siming-installed` 标记正式安装布局。
- 新更新器优先使用 `Siming-Setup.exe`：安装版静默覆盖当前目录并重新启动。
- 安装包更新继续强制 SHA-256 + Authenticode 可信签名校验。
- 正式 Windows Release 收敛为安装包唯一分发：只发布 `Siming-Setup.exe` / `Siming-Setup.sha256`，不再发布 `Siming.exe`、`update.json`、`sha256.txt`。
- `build-installer` 只构建 onedir + Inno Setup，不再额外构建旧单 EXE；打包前会清理遗留单 EXE Release 产物。
- Release Gate 与本地发布脚本会拒绝/删除旧单 EXE Release 资产，避免新用户误下载。
- `build-exe.bat` 仍保留给开发和排障使用，但不属于正式 Release 发布路径。
- Windows Installer CI 在真实 Windows Runner 上编译安装包、验证资产并执行可选安装目录的实际安装冒烟测试，同时保存安装包 Artifact。
- 更新 README 与 PACKAGING 文档，使安装包成为新用户唯一 Windows 下载入口。

## 历史单 EXE 用户

后续不再通过 Release 兼容桥自动迁移。已有单 EXE 用户需要迁移时，直接下载安装当前版本 `Siming-Setup.exe` 即可；程序数据与安装目录分离，既有数据继续保留。

## 验证

PR 包含 updater 单元测试、安装器契约测试、Release 资产契约测试、Windows 构建与实际安装冒烟测试。