### PR TITLE
修复 Android 正文章节顺序混乱

### DIFF
--- a/mobile/android/app/src/main/java/com/siming/mobile/data/local/ReplicaOrdering.kt
+++ b/mobile/android/app/src/main/java/com/siming/mobile/data/local/ReplicaOrdering.kt
@@ -1,5 +1,6 @@
 package com.siming.mobile.data.local
 
+import java.text.Normalizer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -10,8 +11,9 @@ import kotlinx.serialization.json.jsonPrimitive
  *
  * Room's local write time is a transport detail: a bootstrap can insert every
  * chapter in one transaction, so it cannot be used to reconstruct the source
- * order. Imported, unstructured projects have no outline ordering and use the
- * chapter's immutable PC creation time instead.
+ * order. Synced chapters use the immutable PC creation time. Legacy replicas
+ * that do not carry that field fall back to a validated chapter number parsed
+ * from Arabic, full-width, or Chinese-number titles before local timestamps.
  */
 fun orderReplicaEntities(entityType: String, records: List<ReplicaEntity>): List<ReplicaEntity> {
     if (entityType != "chapter" || records.size < 2) return records
@@ -35,14 +37,104 @@ private data class ChapterOrder(
     val titleNumber = payload?.string("title")?.let(::chapterNumber)
 }
 
+private const val MAX_CHAPTER_NUMBER = 99_999
+private const val CHINESE_NUMBER_CHARS = "零〇○一二两三四五六七八九十百千万"
+private val chineseDigits = mapOf(
+    '零' to 0,
+    '〇' to 0,
+    '○' to 0,
+    '一' to 1,
+    '二' to 2,
+    '两' to 2,
+    '三' to 3,
+    '四' to 4,
+    '五' to 5,
+    '六' to 6,
+    '七' to 7,
+    '八' to 8,
+    '九' to 9,
+)
+private val chineseUnits = mapOf(
+    '十' to 10,
+    '百' to 100,
+    '千' to 1_000,
+    '万' to 10_000,
+)
+private val chapterNumberToken =
+    """[0-9０-９$CHINESE_NUMBER_CHARS](?:[0-9０-９$CHINESE_NUMBER_CHARS]|\s)*?"""
 private val chapterNumberPatterns = listOf(
-    Regex("""第\s*(\d+)\s*[章节回]"""),
-    Regex("""(?:chapter|chap\.?)\s*(\d+)""", RegexOption.IGNORE_CASE),
-    Regex("""^\s*(\d+)\b"""),
+    Regex("""第\s*($chapterNumberToken)\s*[章节回]"""),
+    Regex("""(?:^|\s)($chapterNumberToken)\s*[章节回]"""),
+    Regex("""(?:chapter|chap\.?)\s*(\d{1,5})""", RegexOption.IGNORE_CASE),
+    Regex("""^\s*(\d{1,5})\b"""),
 )
 
-private fun chapterNumber(title: String): Int? = chapterNumberPatterns
-    .firstNotNullOfOrNull { pattern -> pattern.find(title)?.groupValues?.getOrNull(1)?.toIntOrNull() }
+private fun chapterNumber(title: String): Int? {
+    val normalized = Normalizer.normalize(title, Normalizer.Form.NFKC)
+    return chapterNumberPatterns.firstNotNullOfOrNull { pattern ->
+        pattern.find(normalized)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.let(::parseChapterNumber)
+    }
+}
+
+private fun parseChapterNumber(text: String): Int? {
+    val number = chineseNumberToInt(text) ?: return null
+    return number.takeIf { it in 1..MAX_CHAPTER_NUMBER }
+}
+
+private fun chineseNumberToInt(text: String): Int? {
+    val value = Regex("""\s+""").replace(
+        Normalizer.normalize(text, Normalizer.Form.NFKC),
+        "",
+    )
+    if (value.isBlank() || value.length > 32) return null
+    value.toIntOrNull()?.let { return it }
+    if (value.any { it !in chineseDigits && it !in chineseUnits }) return null
+
+    if (value.none { it in chineseUnits }) {
+        return value
+            .map { chineseDigits[it] ?: return null }
+            .joinToString("")
+            .toIntOrNull()
+    }
+
+    var total = 0L
+    var section = 0L
+    var number: Int? = null
+    var lastSmallUnit = 10_000
+    var seenWan = false
+    for (char in value) {
+        val digit = chineseDigits[char]
+        if (digit != null) {
+            if (number != null && (number != 0 || digit == 0)) return null
+            if (digit == 0 && total == 0L && section == 0L && number == null) return null
+            number = digit
+            continue
+        }
+
+        val unit = chineseUnits[char] ?: return null
+        if (unit == 10_000) {
+            if (seenWan) return null
+            var base = section + (number ?: 0)
+            if (base == 0L) base = 1L
+            total += base * unit
+            section = 0L
+            number = null
+            lastSmallUnit = 10_000
+            seenWan = true
+        } else {
+            if (unit >= lastSmallUnit || number == 0) return null
+            section += (number ?: 1) * unit
+            number = null
+            lastSmallUnit = unit
+        }
+    }
+    if (number == 0) return null
+    val result = total + section + (number ?: 0)
+    return result.takeIf { it <= Int.MAX_VALUE }?.toInt()
+}
 
 private fun payload(record: ReplicaEntity): JsonObject? = record.payloadJson?.let { raw ->
     runCatching { replicaJson.parseToJsonElement(raw) as? JsonObject }.getOrNull()

--- a/mobile/android/app/src/test/java/com/siming/mobile/data/local/ReplicaOrderingTest.kt
+++ b/mobile/android/app/src/test/java/com/siming/mobile/data/local/ReplicaOrderingTest.kt
@@ -32,6 +32,35 @@ class ReplicaOrderingTest {
         )
     }
 
+    @Test
+    fun legacyChineseChapterTitlesFallBackToSemanticNumber() {
+        val records = listOf(
+            chapter("thirty-four", "第34章 新朋友·壹（小七）", null, 4_000),
+            chapter("eleven", "第十一章 日常", null, 3_000),
+            chapter("four", "第四章 暗流", null, 2_000),
+            chapter("three", "第三章 打回去", null, 1_000),
+        )
+
+        assertEquals(
+            listOf("three", "four", "eleven", "thirty-four"),
+            orderReplicaEntities("chapter", records).map(ReplicaEntity::entityId),
+        )
+    }
+
+    @Test
+    fun chapterNumberFallbackAcceptsFullWidthAndPositionalChineseDigits() {
+        val records = listOf(
+            chapter("one-hundred-three", "第一〇三章", null, 3_000),
+            chapter("twenty-five", "二十五章", null, 2_000),
+            chapter("seven", "第 〇 七 章", null, 1_000),
+        )
+
+        assertEquals(
+            listOf("seven", "twenty-five", "one-hundred-three"),
+            orderReplicaEntities("chapter", records).map(ReplicaEntity::entityId),
+        )
+    }
+
     private fun chapter(id: String, title: String, createdAt: String?, localModifiedAt: Long): ReplicaEntity {
         val createdAtField = createdAt?.let { "\"created_at\":\"$it\"," } ?: ""
         return ReplicaEntity(


### PR DESCRIPTION
## 问题

Android 正文列表的旧副本在缺少 `created_at` 时只能识别阿拉伯数字章节名，`第三章`、`第十一章` 等中文章号会退化到手机本地写入时间排序，导致同步/导入后出现 `第34章 → 第十一章 → 第四章 → 第三章` 这类乱序。

## 修复

- 保留 PC `created_at` 作为正常同步章节的首要顺序来源。
- 对缺失时间戳的旧副本，支持阿拉伯数字、全角数字、中文数字与中文单位章号。
- 支持 `第十一章`、`二十五章`、`第 〇 七 章`、`Chapter 25` 等标题。
- 无法确认的章号继续回退到本地时间和实体 ID，保证排序稳定。

## 回归测试

- 按截图中的 `第34章 / 第十一章 / 第四章 / 第三章` 验证最终顺序为 `3 / 4 / 11 / 34`。
- 覆盖全角数字、中文位置记数与无“第”前缀的章号。
- 保留 PC 创建时间优先的既有测试。