### PR TITLE
修复已同步正文章节仍按创建时间乱序

### DIFF
--- a/mobile/android/app/src/main/java/com/siming/mobile/data/local/ReplicaOrdering.kt
+++ b/mobile/android/app/src/main/java/com/siming/mobile/data/local/ReplicaOrdering.kt
@@ -7,22 +7,23 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Return unstructured chapter replicas in their canonical PC source order.
+ * Return chapter replicas in their semantic reading order.
  *
  * Room's local write time is a transport detail: a bootstrap can insert every
- * chapter in one transaction, so it cannot be used to reconstruct the source
- * order. Synced chapters use the immutable PC creation time. Legacy replicas
- * that do not carry that field fall back to a validated chapter number parsed
- * from Arabic, full-width, or Chinese-number titles before local timestamps.
+ * chapter in one transaction, so it cannot reconstruct the source order. For
+ * numbered titles, the validated chapter number is the cross-device reading
+ * order signal. Unnumbered titles fall back to immutable PC creation time, then
+ * local timestamps and entity IDs for deterministic legacy ordering.
  */
 fun orderReplicaEntities(entityType: String, records: List<ReplicaEntity>): List<ReplicaEntity> {
     if (entityType != "chapter" || records.size < 2) return records
     return records
         .map { record -> ChapterOrder(record, payload(record)) }
         .sortedWith(
-            compareBy<ChapterOrder> { it.createdAt == null }
-                .thenBy { it.createdAt.orEmpty() }
+            compareBy<ChapterOrder> { it.titleNumber == null }
                 .thenBy { it.titleNumber ?: Int.MAX_VALUE }
+                .thenBy { it.createdAt == null }
+                .thenBy { it.createdAt.orEmpty() }
                 .thenBy { it.record.localModifiedAt }
                 .thenBy { it.record.entityId },
         )

--- a/mobile/android/app/src/main/java/com/siming/mobile/data/local/ReplicaOrdering.kt
+++ b/mobile/android/app/src/main/java/com/siming/mobile/data/local/ReplicaOrdering.kt
@@ -10,24 +10,28 @@ import kotlinx.serialization.json.jsonPrimitive
  * Return chapter replicas in their semantic reading order.
  *
  * Room's local write time is a transport detail: a bootstrap can insert every
- * chapter in one transaction, so it cannot reconstruct the source order. For
- * numbered titles, the validated chapter number is the cross-device reading
- * order signal. Unnumbered titles fall back to immutable PC creation time, then
- * local timestamps and entity IDs for deterministic legacy ordering.
+ * chapter in one transaction, so it cannot reconstruct the source order. We
+ * first establish a deterministic PC-time fallback order, then reorder only the
+ * slots occupied by validated numbered titles. This fixes numbered chapters
+ * without pushing unnumbered entries such as prologues or interludes to the end.
  */
 fun orderReplicaEntities(entityType: String, records: List<ReplicaEntity>): List<ReplicaEntity> {
     if (entityType != "chapter" || records.size < 2) return records
-    return records
+
+    val fallbackOrdered = records
         .map { record -> ChapterOrder(record, payload(record)) }
-        .sortedWith(
-            compareBy<ChapterOrder> { it.titleNumber == null }
-                .thenBy { it.titleNumber ?: Int.MAX_VALUE }
-                .thenBy { it.createdAt == null }
-                .thenBy { it.createdAt.orEmpty() }
-                .thenBy { it.record.localModifiedAt }
-                .thenBy { it.record.entityId },
-        )
-        .map(ChapterOrder::record)
+        .sortedWith(chapterFallbackOrder)
+    if (fallbackOrdered.count { it.titleNumber != null } < 2) {
+        return fallbackOrdered.map(ChapterOrder::record)
+    }
+
+    val numbered = fallbackOrdered
+        .filter { it.titleNumber != null }
+        .sortedWith(numberedChapterOrder)
+        .iterator()
+    return fallbackOrdered.map { item ->
+        if (item.titleNumber == null) item.record else numbered.next().record
+    }
 }
 
 private data class ChapterOrder(
@@ -37,6 +41,19 @@ private data class ChapterOrder(
     val createdAt = payload?.string("created_at")?.takeIf(String::isNotBlank)
     val titleNumber = payload?.string("title")?.let(::chapterNumber)
 }
+
+private val chapterFallbackOrder =
+    compareBy<ChapterOrder> { it.createdAt == null }
+        .thenBy { it.createdAt.orEmpty() }
+        .thenBy { it.record.localModifiedAt }
+        .thenBy { it.record.entityId }
+
+private val numberedChapterOrder =
+    compareBy<ChapterOrder> { it.titleNumber ?: Int.MAX_VALUE }
+        .thenBy { it.createdAt == null }
+        .thenBy { it.createdAt.orEmpty() }
+        .thenBy { it.record.localModifiedAt }
+        .thenBy { it.record.entityId }
 
 private const val MAX_CHAPTER_NUMBER = 99_999
 private const val CHINESE_NUMBER_CHARS = "零〇○一二两三四五六七八九十百千万"

--- a/mobile/android/app/src/test/java/com/siming/mobile/data/local/ReplicaOrderingTest.kt
+++ b/mobile/android/app/src/test/java/com/siming/mobile/data/local/ReplicaOrderingTest.kt
@@ -39,6 +39,22 @@ class ReplicaOrderingTest {
     }
 
     @Test
+    fun semanticSortingKeepsUnnumberedChapterSlots() {
+        val records = listOf(
+            chapter("epilogue", "尾声", "2026-08-16T10:00:05.000000Z", 5_000),
+            chapter("three", "第三章", "2026-08-16T10:00:04.000000Z", 4_000),
+            chapter("interlude", "间章", "2026-08-16T10:00:03.000000Z", 3_000),
+            chapter("thirty-four", "第34章", "2026-08-16T10:00:02.000000Z", 2_000),
+            chapter("prologue", "序章", "2026-08-16T10:00:01.000000Z", 1_000),
+        )
+
+        assertEquals(
+            listOf("prologue", "three", "interlude", "thirty-four", "epilogue"),
+            orderReplicaEntities("chapter", records).map(ReplicaEntity::entityId),
+        )
+    }
+
+    @Test
     fun locallyImportedChaptersFallBackToNumberThenCreationTime() {
         val records = listOf(
             chapter("ten", "第10章", null, 3_000),

--- a/mobile/android/app/src/test/java/com/siming/mobile/data/local/ReplicaOrderingTest.kt
+++ b/mobile/android/app/src/test/java/com/siming/mobile/data/local/ReplicaOrderingTest.kt
@@ -5,15 +5,35 @@ import kotlin.test.assertEquals
 
 class ReplicaOrderingTest {
     @Test
-    fun chaptersUseCanonicalCreationTimeInsteadOfLocalBootstrapTime() {
+    fun unnumberedChaptersUseCanonicalCreationTimeInsteadOfLocalBootstrapTime() {
         val records = listOf(
-            chapter("third", "第三章", "2026-08-16T10:00:03.000000Z", 9_999),
-            chapter("first", "第一章", "2026-08-16T10:00:01.000000Z", 9_997),
-            chapter("second", "第二章", "2026-08-16T10:00:02.000000Z", 9_998),
+            chapter("closing", "收束", "2026-08-16T10:00:03.000000Z", 9_999),
+            chapter("opening", "开端", "2026-08-16T10:00:01.000000Z", 9_997),
+            chapter("turning", "转折", "2026-08-16T10:00:02.000000Z", 9_998),
         )
 
         assertEquals(
-            listOf("first", "second", "third"),
+            listOf("opening", "turning", "closing"),
+            orderReplicaEntities("chapter", records).map(ReplicaEntity::entityId),
+        )
+    }
+
+    @Test
+    fun syncedNumberedChaptersPreferSemanticNumberOverCreationTime() {
+        val records = listOf(
+            chapter(
+                "thirty-four",
+                "第34章 新朋友·壹（小七）",
+                "2026-08-16T10:00:01.000000Z",
+                4_000,
+            ),
+            chapter("eleven", "第十一章 日常", "2026-08-16T10:00:02.000000Z", 3_000),
+            chapter("four", "第四章 暗流", "2026-08-16T10:00:03.000000Z", 2_000),
+            chapter("three", "第三章 打回去", "2026-08-16T10:00:04.000000Z", 1_000),
+        )
+
+        assertEquals(
+            listOf("three", "four", "eleven", "thirty-four"),
             orderReplicaEntities("chapter", records).map(ReplicaEntity::entityId),
         )
     }


### PR DESCRIPTION
## 根因

上一版已经能解析中文章号，但排序器仍把 `created_at` 放在章号之前。PC Gateway 同步的章节本身都会携带 `created_at`，因此在截图对应的“PC API 一致模式”中，章号解析结果实际上不会参与主要排序；只要历史创建时间与正文顺序不同，列表就仍会显示成 `第34章 → 第十一章 → 第四章 → 第三章`。

## 修复

- 先按 PC `created_at`、本机时间和实体 ID 建立稳定的兜底顺序。
- 再只对“可可靠解析章号”的章节槽位按语义章号重排。
- `序章`、`间章`、`尾声`等无编号条目仍保留在兜底顺序中的原位置，不会被统一推到列表末尾。
- 保留中文数字、全角数字、无“第”前缀和英文 `Chapter` 标题支持。

## 回归测试

- 带有非顺序 `created_at` 的截图场景最终按 `3 → 4 → 11 → 34` 显示。
- 无编号章节继续按 PC 创建时间排序。
- 混合 `序章 / 编号章 / 间章 / 尾声` 时，无编号章节位置保持稳定。