### PR TITLE
建立 Android / PC 能力对齐契约

### DIFF
--- a/.github/workflows/architecture-ci.yml
+++ b/.github/workflows/architecture-ci.yml
@@ -5,7 +5,12 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - "mobile/android/**"
+      - "contracts/mobile-pc-parity.json"
+      - "docs/mobile-pc-parity.md"
       - "scripts/check-architecture.py"
+      - "scripts/check-mobile-pc-parity.py"
+      - "scripts/export-mobile-prompt-contract.py"
       - "scripts/run-performance-baseline.py"
       - ".jscpd.json"
       - ".github/workflows/architecture-ci.yml"
@@ -14,7 +19,12 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - "mobile/android/**"
+      - "contracts/mobile-pc-parity.json"
+      - "docs/mobile-pc-parity.md"
       - "scripts/check-architecture.py"
+      - "scripts/check-mobile-pc-parity.py"
+      - "scripts/export-mobile-prompt-contract.py"
       - ".jscpd.json"
       - ".github/workflows/architecture-ci.yml"
 
@@ -40,6 +50,9 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+
+      - name: Validate Android / PC parity contract
+        run: python scripts/check-mobile-pc-parity.py --check-doc docs/mobile-pc-parity.md
 
       - name: Install backend dependencies
         working-directory: backend

--- a/backend/tests/test_mobile_pc_parity_contract.py
+++ b/backend/tests/test_mobile_pc_parity_contract.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_mobile_pc_parity_contract_is_source_backed_and_documented() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "check-mobile-pc-parity.py"),
+            "--root",
+            str(ROOT),
+            "--check-doc",
+            "docs/mobile-pc-parity.md",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/contracts/mobile-pc-parity.json
+++ b/contracts/mobile-pc-parity.json
@@ -1,0 +1,1752 @@
+{
+  "schema_version": 1,
+  "contract_version": "2026-08-17",
+  "canonical_authority": "pc",
+  "modes": {
+    "pc": "桌面后端和前端所使用的权威领域实现。",
+    "android_online": "Android 已连接 PC Gateway，优先调用 PC HTTP/Agent 能力。",
+    "android_offline": "Android 无 Gateway，仅使用本地副本与可回放 outbox。",
+    "android_standalone": "Android 配置独立模型，运行本地 Agent 和本地工具适配器。"
+  },
+  "coverage_targets": [
+    {
+      "id": "pc_api_paths",
+      "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPaths.kt",
+      "extractor": "kotlin_functions",
+      "symbols": {
+        "project": "authoring.project",
+        "chapterReorder": "chapter.reorder",
+        "chapterSnapshots": "chapter.history",
+        "chapterSnapshotDiff": "chapter.history",
+        "chapterSnapshot": "chapter.history",
+        "chapterRestore": "chapter.restore",
+        "characterRelationshipNetwork": "character.relationships",
+        "characterRelationships": "character.relationships",
+        "characterAiConfig": "character.ai_config",
+        "characterVersions": "character.versions",
+        "characterVersion": "character.versions",
+        "worldVersions": "worldbuilding.history",
+        "worldTimeline": "worldbuilding.history",
+        "assistantStream": "assistant.workspace",
+        "novelCreationSession": "novel_creation.session",
+        "novelCreationRuns": "novel_creation.session",
+        "novelCreationRun": "novel_creation.session",
+        "novelCreationStageConfirm": "novel_creation.session",
+        "novelCreationStage": "novel_creation.session",
+        "narrativeGovernanceItems": "governance.items",
+        "narrativeGovernanceStatus": "governance.items",
+        "conflictResolution": "sync.conflicts"
+      },
+      "ignore_symbols": {
+        "authoringCollection": "Generic route factory; individual authoring capabilities own the semantic decision.",
+        "authoringItem": "Generic route factory; individual authoring capabilities own the semantic decision.",
+        "segment": "Path-segment validation helper, not a user capability."
+      }
+    },
+    {
+      "id": "pc_authoring_contract_types",
+      "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcAuthoringContract.kt",
+      "extractor": "kotlin_map_list_keys",
+      "symbols": {
+        "project": "authoring.project",
+        "chapter": "authoring.chapter",
+        "outline": "authoring.outline",
+        "character": "authoring.character",
+        "character_relation": "character.relationships",
+        "character_ai_config": "character.ai_config",
+        "world": "authoring.worldbuilding",
+        "world_relation": "worldbuilding.relationships",
+        "foreshadowing": "governance.items",
+        "governance": "governance.items"
+      },
+      "ignore_symbols": {}
+    },
+    {
+      "id": "standalone_workspace_tools",
+      "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+      "extractor": "kotlin_when_strings",
+      "start_marker": "private suspend fun execute(",
+      "end_marker": "private suspend fun getProjectInfo(",
+      "symbols": {
+        "get_project_info": "authoring.project",
+        "update_project_info": "authoring.project",
+        "list_characters": "authoring.character",
+        "search_characters": "authoring.character",
+        "create_character": "authoring.character",
+        "update_character": "authoring.character",
+        "list_chapters": "authoring.chapter",
+        "search_chapters": "authoring.chapter",
+        "create_chapter": "authoring.chapter",
+        "update_chapter": "authoring.chapter",
+        "search_outline": "authoring.outline",
+        "search_outline_tree": "authoring.outline",
+        "create_outline_node": "authoring.outline",
+        "create_outline_nodes": "authoring.outline",
+        "update_outline_node": "authoring.outline",
+        "list_worldbuilding": "authoring.worldbuilding",
+        "search_worldbuilding": "authoring.worldbuilding",
+        "create_worldbuilding_entry": "authoring.worldbuilding",
+        "update_worldbuilding_entry": "authoring.worldbuilding",
+        "preview_writing_context": "context.preview",
+        "chapter_writer": "writer.chapter",
+        "character_writer": "writer.character",
+        "outline_writer": "writer.outline",
+        "worldbuilding_writer": "writer.worldbuilding"
+      },
+      "ignore_symbols": {}
+    }
+  ],
+  "capabilities": [
+    {
+      "id": "assistant.workspace",
+      "area": "assistant",
+      "summary": "统一的工作区 Agent 对话与工具循环",
+      "status": "partial",
+      "authority": {
+        "type": "pc_workspace_tool",
+        "entrypoint": "workspace assistant stream / MobileWorkspaceAgent",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/ai_writer.py",
+            "contains": "workspace-assistant/stream"
+          },
+          {
+            "path": "backend/app/services/workspace/assistant_stream_runtime.py",
+            "contains": "async def"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun streamAssistant("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "没有 Gateway 且未配置手机直连模型时不启动 Agent。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "internal class MobileWorkspaceAgent("
+            },
+            {
+              "path": "scripts/export-mobile-prompt-contract.py",
+              "contains": "MOBILE_TOOL_NAMES = ["
+            }
+          ],
+          "limitations": "共享生成后的提示词与工具 schema，但工具执行、上下文选择和审计仍是 Android 本地实现。"
+        }
+      },
+      "side_effects": [],
+      "idempotency": {
+        "required": false,
+        "strategy": "not_applicable"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_workspace_assistant_outcome.py",
+          "contains": "test_"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/DirectApiClientTest.kt",
+          "contains": "class DirectApiClientTest"
+        }
+      ],
+      "known_gaps": [
+        "手机独立 Agent 尚未共享 PC 的 ContextManifest、运行日志和完整恢复语义。"
+      ]
+    },
+    {
+      "id": "authoring.chapter",
+      "area": "authoring",
+      "summary": "章节创建、读取、更新和删除",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/api/v1/projects/{project_id}/chapters",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/chapters.py",
+            "contains": "@router.post(\"/projects/{project_id}/chapters\")"
+          },
+          {
+            "path": "backend/app/modules/story/infrastructure/chapters.py",
+            "contains": "class SqlAlchemyChapterWorkspace"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun saveAuthoringEntity("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"chapter\" -> \"chapter\""
+            },
+            {
+              "path": "backend/app/services/gateway_legacy_replication.py",
+              "contains": "if spec.model is Chapter and row_existed:"
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"create_chapter\" -> createChapter"
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"update_chapter\" -> updateChapter"
+            }
+          ],
+          "notes": "先写本地副本与 outbox，连接 PC 后由领域服务回放。"
+        }
+      },
+      "side_effects": [
+        "chapter_snapshot",
+        "narrative_checkpoint",
+        "cataloging",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_chapters.py",
+          "contains": "test_save_chapter_creates_snapshot_with_new_content"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/local/CanonicalReplicaContractTest.kt",
+          "contains": "standaloneAuthoringSnapshotDropsVersionRowsButKeepsDedicatedContextEntities"
+        }
+      ]
+    },
+    {
+      "id": "authoring.character",
+      "area": "authoring",
+      "summary": "角色卡创建、读取、更新和删除",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/api/v1/projects/{project_id}/characters",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "@router.post(\"/projects/{project_id}/characters\")"
+          },
+          {
+            "path": "backend/app/services/persistence/character_workspace.py",
+            "contains": "class SqlAlchemyCharacterWorkspace"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun saveAuthoringEntity("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"character\" -> \"character\""
+            },
+            {
+              "path": "backend/app/services/gateway_legacy_replication.py",
+              "contains": "elif spec.model is Character:"
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"create_character\" -> createCharacter"
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"update_character\" -> updateCharacter"
+            }
+          ],
+          "notes": "本地写入统一投影为 PC Character 公共契约。"
+        }
+      },
+      "side_effects": [
+        "character_version",
+        "alias_sync",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_characters.py",
+          "contains": "test_update_character_increments_version_and_writes_snapshot"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcApiPayloadsTest.kt",
+          "contains": "class PcApiPayloadsTest"
+        }
+      ]
+    },
+    {
+      "id": "authoring.outline",
+      "area": "authoring",
+      "summary": "大纲节点创建、读取和更新",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/api/v1/projects/{project_id}/outline",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/outline.py",
+            "contains": "APIRouter"
+          },
+          {
+            "path": "backend/app/services/gateway_legacy_replication.py",
+            "contains": "elif spec.model is OutlineNode:"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun saveAuthoringEntity("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"outline\" -> \"outline_node\""
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"create_outline_node\" -> createOutlineNode"
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"update_outline_node\" -> updateOutlineNode"
+            }
+          ]
+        }
+      },
+      "side_effects": [
+        "cycle_validation",
+        "character_link_replace",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcApiPayloadsTest.kt",
+          "contains": "class PcApiPayloadsTest"
+        },
+        {
+          "path": "backend/tests/test_gateway_canonical_entity_contract.py",
+          "contains": "test_outline_mobile_mutation_maps_pc_metadata_and_character_links"
+        }
+      ]
+    },
+    {
+      "id": "authoring.project",
+      "area": "authoring",
+      "summary": "作品资料读取与更新",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/api/v1/projects/{project_id}",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/projects.py",
+            "contains": "APIRouter"
+          },
+          {
+            "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPaths.kt",
+            "contains": "fun project(projectId: String)"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun createProject("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"project\" -> \"project\""
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"update_project_info\" -> updateProjectInfo"
+            }
+          ]
+        }
+      },
+      "side_effects": [
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_projects.py",
+          "contains": "test_"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcApiPayloadsTest.kt",
+          "contains": "class PcApiPayloadsTest"
+        }
+      ]
+    },
+    {
+      "id": "authoring.worldbuilding",
+      "area": "authoring",
+      "summary": "世界观条目创建、读取、更新和删除",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/api/v1/projects/{project_id}/worldbuilding",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/worldbuilding.py",
+            "contains": "APIRouter"
+          },
+          {
+            "path": "backend/app/modules/story/infrastructure/worldbuilding.py",
+            "contains": "class SqlAlchemyWorldbuildingWorkspace"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun saveAuthoringEntity("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"world\" -> \"world_entry\""
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"create_worldbuilding_entry\" -> createWorldbuilding"
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "\"update_worldbuilding_entry\" -> updateWorldbuilding"
+            }
+          ]
+        }
+      },
+      "side_effects": [
+        "world_version",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_worldbuilding.py",
+          "contains": "test_update_worldbuilding_entry"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcApiPayloadsTest.kt",
+          "contains": "class PcApiPayloadsTest"
+        }
+      ]
+    },
+    {
+      "id": "chapter.history",
+      "area": "chapter",
+      "summary": "章节快照列表、详情与差异比较",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "GET /chapters/{chapter_id}/snapshots[/diff/{snapshot_id}]",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/chapters.py",
+            "contains": "def list_chapter_snapshots("
+          },
+          {
+            "path": "backend/app/routers/chapters.py",
+            "contains": "def diff_chapter_snapshots("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "read_only_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun listChapterSnapshots("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun diffChapterSnapshots("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "高级历史页面明确要求连接 PC Gateway，避免把不完整缓存当作权威版本。"
+        },
+        "android_standalone": {
+          "support": "unsupported",
+          "reason": "手机独立 Agent 不维护 PC 版本账本。"
+        }
+      },
+      "side_effects": [],
+      "idempotency": {
+        "required": false,
+        "strategy": "read_only"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_chapters.py",
+          "contains": "test_diff_between_two_snapshots"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcAdvancedPathsTest.kt",
+          "contains": "chapter advanced commands use canonical PC routes"
+        }
+      ],
+      "known_gaps": [
+        "离线副本中即使存在历史记录也不会开放恢复或 diff，以免版本链不完整。"
+      ]
+    },
+    {
+      "id": "chapter.reorder",
+      "area": "chapter",
+      "summary": "章节权威阅读顺序重排",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "PUT /api/v1/projects/{project_id}/chapters/reorder",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/chapters.py",
+            "contains": "def reorder_chapters("
+          },
+          {
+            "path": "backend/app/modules/story/infrastructure/chapters.py",
+            "contains": "def reorder(self, project_id: str, chapter_ids: list[str])"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/SimingRepository.kt",
+              "contains": "suspend fun reorderChapters("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "排序必须一次提交当前作品全部章节，离线副本不能猜测 authoritative sort_order。"
+        },
+        "android_standalone": {
+          "support": "blocked",
+          "reason": "独立 Agent 不直接改变 PC 权威章节顺序。"
+        }
+      },
+      "side_effects": [
+        "authoritative_reorder",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "set_replacement"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_chapters.py",
+          "contains": "test_list_chapters_keeps_reading_order_independent_from_outline_tree"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcAdvancedPathsTest.kt",
+          "contains": "chapter advanced commands use canonical PC routes"
+        }
+      ]
+    },
+    {
+      "id": "chapter.restore",
+      "area": "chapter",
+      "summary": "从历史快照恢复章节及关联叙事状态",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "POST /chapters/{chapter_id}/restore/{snapshot_id}",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/chapters.py",
+            "contains": "async def restore_chapter_snapshot("
+          },
+          {
+            "path": "backend/app/modules/story/infrastructure/chapters.py",
+            "contains": "def restore("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/SimingRepository.kt",
+              "contains": "suspend fun restoreChapterSnapshot("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/ui/AdvancedAuthoringDialogs.kt",
+              "contains": "var restoring by remember"
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "恢复会创建新版本并恢复 ledger，必须连接 PC。"
+        },
+        "android_standalone": {
+          "support": "blocked",
+          "reason": "独立 Agent 不具备 PC ledger/checkpoint 权威数据。"
+        }
+      },
+      "side_effects": [
+        "chapter_restore",
+        "chapter_snapshot",
+        "ledger_restore",
+        "governance_invalidation",
+        "cataloging",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "client_serialization",
+        "limitations": "Android 已串行化恢复并阻止重复点击；PC 恢复接口每次调用仍会创建一个新 restore 版本，后续应增加服务端 request key。"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_chapters.py",
+          "contains": "test_restore_snapshot_creates_restore_snapshot"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcCanonicalCommandResultTest.kt",
+          "contains": "refresh failure keeps successful command payload"
+        }
+      ]
+    },
+    {
+      "id": "character.ai_config",
+      "area": "character",
+      "summary": "角色专用语气、口头禅与模型配置",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "GET/PUT /characters/{character_id}/ai-config",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "def get_character_ai_config("
+          },
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "def update_character_ai_config("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun updateCharacterAiConfig("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"character_ai_config\" -> values.normalizeStringArray(\"catchphrases\")"
+            },
+            {
+              "path": "backend/app/services/gateway_legacy_replication.py",
+              "contains": "角色 AI 配置不能移动到其他角色"
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "unsupported",
+          "reason": "手机独立 Agent 不消费 CharacterAIConfig；普通章节写作明确避免错误注入。"
+        }
+      },
+      "side_effects": [
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_gateway_auxiliary_authoring_contract.py",
+          "contains": "test_character_ai_config_cannot_move_to_another_character"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcAuxiliaryPayloadsTest.kt",
+          "contains": "character AI config keeps catchphrases as PC string array"
+        }
+      ],
+      "known_gaps": [
+        "CharacterAIConfig 仅在连接 PC 的高级页面和同步回放中可用，尚未接入手机独立角色扮演能力。"
+      ]
+    },
+    {
+      "id": "character.relationships",
+      "area": "character",
+      "summary": "有方向的角色关系网读取与替换",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "GET /characters/relationships; PUT /characters/{character_id}/relationships",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "def get_relationship_network("
+          },
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "def update_character_relationships("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcRelationshipEditorContract.kt",
+              "contains": "internal data class PcEditableRelationship"
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun replaceCharacterRelationships("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"character_relation\" -> {"
+            },
+            {
+              "path": "backend/app/services/gateway_legacy_replication.py",
+              "contains": "def _canonical_character_relation_values("
+            }
+          ],
+          "notes": "离线以单条有向边回放，不模拟在线“替换当前角色全部关系”的事务。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextParity.kt",
+              "contains": "internal fun pcRelationshipPayloads("
+            }
+          ],
+          "limitations": "能消费缓存关系并写入创作上下文，但没有离线专用完整关系网编辑器。"
+        }
+      },
+      "side_effects": [
+        "relationship_replace",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "set_replacement"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_characters.py",
+          "contains": "test_editing_from_target_endpoint_preserves_direction"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcRelationshipEditorContractTest.kt",
+          "contains": "editing from target endpoint preserves original direction"
+        }
+      ],
+      "known_gaps": [
+        "手机在线编辑复用 PC 全量替换接口；离线回放仍是逐边 upsert，事务语义不同。"
+      ]
+    },
+    {
+      "id": "character.versions",
+      "area": "character",
+      "summary": "角色版本列表与历史快照查看",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "GET /characters/{character_id}/versions[/{version_id}]",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "def list_character_versions("
+          },
+          {
+            "path": "backend/app/routers/characters.py",
+            "contains": "def get_character_version("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "read_only_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun listCharacterVersions("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "离线列表可能缺少完整历史，界面不把缓存冒充权威版本。"
+        },
+        "android_standalone": {
+          "support": "unsupported",
+          "reason": "独立 Agent 不维护角色版本账本。"
+        }
+      },
+      "side_effects": [],
+      "idempotency": {
+        "required": false,
+        "strategy": "read_only"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_characters.py",
+          "contains": "test_update_character_increments_version_and_writes_snapshot"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcAdvancedPathsTest.kt",
+          "contains": "character advanced commands use canonical PC routes"
+        }
+      ],
+      "known_gaps": [
+        "Android 当前只读查看，尚未提供角色历史恢复。"
+      ]
+    },
+    {
+      "id": "context.preview",
+      "area": "context",
+      "summary": "写章前上下文预检",
+      "status": "partial",
+      "authority": {
+        "type": "pc_workspace_tool",
+        "entrypoint": "preview_writing_context",
+        "source_refs": [
+          {
+            "path": "backend/app/services/workspace/tools/context_preview.py",
+            "contains": "async def preview_writing_context("
+          },
+          {
+            "path": "backend/app/services/context_orchestrator.py",
+            "contains": "class ContextOrchestrator"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun streamAssistant("
+            }
+          ],
+          "notes": "通过 PC workspace assistant 调用同一工具。"
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "没有模型执行路由时只保留资料缓存，不运行上下文预检。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "private suspend fun previewWritingContext("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextParity.kt",
+              "contains": "internal fun pcGovernanceContext("
+            }
+          ],
+          "limitations": "角色、关系和治理优先级已复刻，但没有 PC RAG、FTS、ContextManifest、source hash 和预算覆盖判定。"
+        }
+      },
+      "side_effects": [],
+      "idempotency": {
+        "required": false,
+        "strategy": "read_only"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_workspace_context_preview.py",
+          "contains": "test_preview_writing_context_returns_state_and_warnings"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextParityTest.kt",
+          "contains": "governance context keeps only latest state per character"
+        }
+      ],
+      "known_gaps": [
+        "手机独立预检仍是 Kotlin 近似实现，下一阶段应改为版本化 ContextManifest 契约。"
+      ]
+    },
+    {
+      "id": "governance.items",
+      "area": "governance",
+      "summary": "伏笔、叙事债务及生命周期状态操作",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/narrative-governance/items[/{type}/{id}]",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/narrative_governance.py",
+            "contains": "APIRouter"
+          },
+          {
+            "path": "backend/app/services/narrative_governance.py",
+            "contains": "def governance_context("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun saveGovernanceEntity("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun updateGovernanceStatus("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "fun governanceContent("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "fun governanceStatus("
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextParity.kt",
+              "contains": "internal fun pcGovernanceContext("
+            }
+          ],
+          "limitations": "可读取最新治理锁并用于写章，但独立 Agent 未开放治理项创建、复检和关闭工具。"
+        }
+      },
+      "side_effects": [
+        "governance_transition",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_narrative_governance.py",
+          "contains": "test_verified_close_requires_repair_then_review_evidence"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextParityTest.kt",
+          "contains": "governance context mirrors PC open statuses and priority ordering"
+        }
+      ],
+      "known_gaps": [
+        "手机独立 Agent 目前只消费治理锁，不执行治理生命周期命令。"
+      ]
+    },
+    {
+      "id": "novel_creation.session",
+      "area": "novel_creation",
+      "summary": "对话式立项会话、阶段确认和正式归档",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "/api/v1/novel-creation/*",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/novel_creation.py",
+            "contains": "APIRouter"
+          },
+          {
+            "path": "backend/app/services/novel_creation_workspace.py",
+            "contains": "initialize_session_draft"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun startNovelCreation("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun confirmNovelCreationStage("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "local_cache",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/creation/MobileCreationConversationAgent.kt",
+              "contains": "class MobileCreationConversationAgent"
+            }
+          ],
+          "notes": "会话先保存在手机，正式归档后进入规范同步。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/creation/MobileCreationAgent.kt",
+              "contains": "class MobileCreationAgent"
+            },
+            {
+              "path": "scripts/export-mobile-prompt-contract.py",
+              "contains": "_creation_baseline_fixture"
+            }
+          ],
+          "limitations": "共享 PC 提示词、阶段规范和基线夹具，但运行状态机、恢复与并发控制仍是手机实现。"
+        }
+      },
+      "side_effects": [
+        "project_archive",
+        "structured_entities",
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "request_key"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_novel_creation_compact_flow.py",
+          "contains": "test_"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/creation/PcCreationAgentContractTest.kt",
+          "contains": "currentPcCreationAgentPromptRequiresImmediateIncrementalWrites"
+        }
+      ],
+      "known_gaps": [
+        "手机独立立项尚未完全复用 PC 的运行记录、暂停/恢复和操作幂等状态机。"
+      ]
+    },
+    {
+      "id": "sync.conflicts",
+      "area": "sync",
+      "summary": "同步冲突查看与用户选择解决",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_sync_protocol",
+        "entrypoint": "POST /api/v1/sync/conflicts/{conflict_id}/resolve",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/gateway.py",
+            "contains": "conflicts"
+          },
+          {
+            "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPaths.kt",
+            "contains": "fun conflictResolution("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun resolveConflict("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "冲突选择必须读取服务端当前分支。"
+        },
+        "android_standalone": {
+          "support": "not_applicable",
+          "reason": "未连接 Gateway 时没有远端冲突可解决。"
+        }
+      },
+      "side_effects": [
+        "conflict_resolution",
+        "sync_cursor"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "server_transaction"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_gateway_sync.py",
+          "contains": "test_same_entity_divergence_preserves_both_versions"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/UserFacingErrorTest.kt",
+          "contains": "class UserFacingErrorTest"
+        }
+      ]
+    },
+    {
+      "id": "sync.replication",
+      "area": "sync",
+      "summary": "修订、outbox、bootstrap、push/pull 和 tombstone 同步",
+      "status": "aligned",
+      "authority": {
+        "type": "pc_sync_protocol",
+        "entrypoint": "/api/v1/sync/{bootstrap,push,pull}",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/gateway.py",
+            "contains": "@router.post(\"/sync/push\""
+          },
+          {
+            "path": "backend/app/services/gateway_legacy_replication.py",
+            "contains": "def project_snapshots("
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/SimingRepository.kt",
+              "contains": "suspend fun syncNow()"
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "local_cache",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/SimingRepository.kt",
+              "contains": "private suspend fun pushPending("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/SimingRepository.kt",
+              "contains": "private suspend fun deleteOfflineEntity("
+            }
+          ],
+          "notes": "本地修订和 tombstone 保存在 Room/outbox。"
+        },
+        "android_standalone": {
+          "support": "local_cache",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "private val saveEntity"
+            }
+          ],
+          "notes": "Agent 写入同一副本/outbox。"
+        }
+      },
+      "side_effects": [
+        "revision_order",
+        "tombstone",
+        "conflict_detection",
+        "sync_cursor"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_gateway_sync.py",
+          "contains": "test_sync_is_ordered_idempotent_and_merges_different_entities"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/local/CanonicalReplicaContractTest.kt",
+          "contains": "class CanonicalReplicaContractTest"
+        }
+      ]
+    },
+    {
+      "id": "worldbuilding.history",
+      "area": "worldbuilding",
+      "summary": "世界观版本与时间线查看",
+      "status": "partial",
+      "authority": {
+        "type": "pc_http",
+        "entrypoint": "GET /worldbuilding/{entry_id}/{versions|timeline}",
+        "source_refs": [
+          {
+            "path": "backend/app/routers/worldbuilding.py",
+            "contains": "versions"
+          },
+          {
+            "path": "backend/app/routers/worldbuilding.py",
+            "contains": "timeline"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "read_only_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun listWorldVersions("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun listWorldTimeline("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "历史入口要求完整 PC 版本链。"
+        },
+        "android_standalone": {
+          "support": "unsupported",
+          "reason": "手机独立 Agent 不维护世界观版本和时间线账本。"
+        }
+      },
+      "side_effects": [],
+      "idempotency": {
+        "required": false,
+        "strategy": "read_only"
+      },
+      "tests": [
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcWorldAdvancedPathsTest.kt",
+          "contains": "worldbuilding history uses canonical PC routes"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/local/CanonicalReplicaContractTest.kt",
+          "contains": "worldHistoryDoesNotBecomeUnnamedWorldCards"
+        }
+      ],
+      "known_gaps": [
+        "Android 当前只读查看，尚未提供世界观历史恢复。"
+      ]
+    },
+    {
+      "id": "worldbuilding.relationships",
+      "area": "worldbuilding",
+      "summary": "世界观条目之间的结构化关系边",
+      "status": "partial",
+      "authority": {
+        "type": "pc_sync_protocol",
+        "entrypoint": "WorldbuildingRelation sync record",
+        "source_refs": [
+          {
+            "path": "backend/app/services/gateway_legacy_replication.py",
+            "contains": "WorldbuildingRelation: frozenset("
+          },
+          {
+            "path": "backend/app/modules/story/infrastructure/entities.py",
+            "contains": "class WorldbuildingRelation"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcApiPayloads.kt",
+              "contains": "\"world_relation\" -> values.normalizeJsonObject"
+            }
+          ],
+          "notes": "当前没有专用 PC HTTP 编辑路由，在线写入仍走同步契约。"
+        },
+        "android_offline": {
+          "support": "sync_replay",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/PcAuthoringContract.kt",
+              "contains": "\"world_relation\" to listOf("
+            }
+          ]
+        },
+        "android_standalone": {
+          "support": "unsupported",
+          "reason": "世界观写作上下文尚未消费 WorldbuildingRelation。"
+        }
+      },
+      "side_effects": [
+        "content_sync"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "revisioned_outbox"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_gateway_auxiliary_authoring_contract.py",
+          "contains": "test_auxiliary_relationship_and_ai_config_contracts_round_trip"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcAuxiliaryPayloadsTest.kt",
+          "contains": "world relation metadata stays a JSON object"
+        }
+      ],
+      "known_gaps": [
+        "PC 尚无世界观关系专用 HTTP 领域命令；手机独立写作也尚未消费关系边。"
+      ]
+    },
+    {
+      "id": "writer.chapter",
+      "area": "context",
+      "summary": "根据大纲和受治理上下文生成章节草稿",
+      "status": "partial",
+      "authority": {
+        "type": "pc_workspace_tool",
+        "entrypoint": "chapter_writer",
+        "source_refs": [
+          {
+            "path": "backend/app/services/workspace/tools/chapter_writer.py",
+            "contains": "async def chapter_writer("
+          },
+          {
+            "path": "backend/app/services/context_orchestrator.py",
+            "contains": "TASK_CONTEXT_CONTRACTS"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun streamAssistant("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "无模型执行路由时只编辑资料，不生成正文。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "private suspend fun chapterWriter("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextParity.kt",
+              "contains": "internal fun pcCharacterDetails("
+            }
+          ],
+          "limitations": "共享章节提示词并消费角色关系/治理锁，但未使用 ContextManifest、RAG、source hash、预算和 stale 校验。"
+        }
+      },
+      "side_effects": [
+        "draft_store"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "draft_reference"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_context_orchestrator.py",
+          "contains": "test_writing_manifest_consumes_full_character_card_and_relationships"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextParityTest.kt",
+          "contains": "relationship preview uses PC names and selected endpoint semantics"
+        }
+      ],
+      "known_gaps": [
+        "手机独立写章是当前最大语义差距，下一阶段必须共享 ContextManifest 选择和审计契约。"
+      ]
+    },
+    {
+      "id": "writer.character",
+      "area": "context",
+      "summary": "根据作品与世界观生成结构化角色卡",
+      "status": "partial",
+      "authority": {
+        "type": "pc_workspace_tool",
+        "entrypoint": "character_writer",
+        "source_refs": [
+          {
+            "path": "backend/app/services/workspace/tools/character_writer.py",
+            "contains": "async def character_writer("
+          },
+          {
+            "path": "backend/app/prompts/character_writer_prompts.py",
+            "contains": "build_character_writer_messages"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun streamAssistant("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "没有手机直连模型时不运行生成器。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "private suspend fun characterWriter("
+            },
+            {
+              "path": "scripts/export-mobile-prompt-contract.py",
+              "contains": "CHARACTER_CARD_TOOL"
+            }
+          ],
+          "limitations": "提示词和输出工具由 PC 构建时导出，但上下文检索和后续领域副作用在手机端执行。"
+        }
+      },
+      "side_effects": [
+        "draft_store"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "draft_reference"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_mobile_prompt_contract.py",
+          "contains": "test_android_prompt_contract_contains_full_nested_writer_pipeline"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/creation/PcCreationAgentContractTest.kt",
+          "contains": "class PcCreationAgentContractTest"
+        }
+      ],
+      "known_gaps": [
+        "手机独立生成器尚未绑定 PC ContextManifest 和运行审计。"
+      ]
+    },
+    {
+      "id": "writer.outline",
+      "area": "context",
+      "summary": "生成结构化大纲节点",
+      "status": "partial",
+      "authority": {
+        "type": "pc_workspace_tool",
+        "entrypoint": "outline_writer",
+        "source_refs": [
+          {
+            "path": "backend/app/services/workspace/tools/outline_writer.py",
+            "contains": "async def outline_writer("
+          },
+          {
+            "path": "backend/app/prompts/outline_writer_prompts.py",
+            "contains": "build_outline_writer_messages"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun streamAssistant("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "没有手机直连模型时不运行生成器。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "private suspend fun outlineWriter("
+            },
+            {
+              "path": "scripts/export-mobile-prompt-contract.py",
+              "contains": "OUTLINE_NODES_TOOL"
+            }
+          ],
+          "limitations": "提示词和输出工具共享，批次限制与本地上下文选择仍由 Kotlin 实现。"
+        }
+      },
+      "side_effects": [
+        "draft_store"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "draft_reference"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_mobile_prompt_contract.py",
+          "contains": "test_android_prompt_contract_contains_full_nested_writer_pipeline"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/local/CanonicalReplicaContractTest.kt",
+          "contains": "class CanonicalReplicaContractTest"
+        }
+      ],
+      "known_gaps": [
+        "手机独立生成器尚未绑定 PC ContextManifest 和运行审计。"
+      ]
+    },
+    {
+      "id": "writer.worldbuilding",
+      "area": "context",
+      "summary": "生成结构化世界观条目",
+      "status": "partial",
+      "authority": {
+        "type": "pc_workspace_tool",
+        "entrypoint": "worldbuilding_writer",
+        "source_refs": [
+          {
+            "path": "backend/app/services/workspace/tools/worldbuilding_writer.py",
+            "contains": "async def worldbuilding_writer("
+          },
+          {
+            "path": "backend/app/prompts/worldbuilding_writer_prompts.py",
+            "contains": "build_worldbuilding_writer_messages"
+          }
+        ]
+      },
+      "modes": {
+        "pc": {
+          "support": "canonical"
+        },
+        "android_online": {
+          "support": "canonical_proxy",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/network/GatewayApi.kt",
+              "contains": "suspend fun streamAssistant("
+            }
+          ]
+        },
+        "android_offline": {
+          "support": "blocked",
+          "reason": "没有手机直连模型时不运行生成器。"
+        },
+        "android_standalone": {
+          "support": "degraded",
+          "source_refs": [
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt",
+              "contains": "private suspend fun worldbuildingWriter("
+            },
+            {
+              "path": "scripts/export-mobile-prompt-contract.py",
+              "contains": "WORLDBUILDING_ENTRY_TOOL"
+            }
+          ],
+          "limitations": "提示词和输出工具共享，但未消费世界观关系边，也没有 PC 上下文清单审计。"
+        }
+      },
+      "side_effects": [
+        "draft_store"
+      ],
+      "idempotency": {
+        "required": true,
+        "strategy": "draft_reference"
+      },
+      "tests": [
+        {
+          "path": "backend/tests/test_mobile_prompt_contract.py",
+          "contains": "test_android_prompt_contract_contains_full_nested_writer_pipeline"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/network/PcAuxiliaryPayloadsTest.kt",
+          "contains": "world relation metadata stays a JSON object"
+        }
+      ],
+      "known_gaps": [
+        "手机独立世界观生成尚未消费 WorldbuildingRelation 或 ContextManifest。"
+      ]
+    }
+  ]
+}

--- a/docs/mobile-pc-parity.md
+++ b/docs/mobile-pc-parity.md
@@ -1,0 +1,326 @@
+# Android ↔ PC 能力对齐契约
+
+> 本文由 `contracts/mobile-pc-parity.json` 通过 `scripts/check-mobile-pc-parity.py` 生成；请勿手工修改。
+
+PC 是小说数据、领域副作用和上下文治理的唯一权威实现。Android 在线模式应尽量作为薄客户端；离线模式只允许可验证回放的修订；手机独立 Agent 的降级能力必须显式记录。
+
+当前共登记 **23** 项能力：**9** 项已对齐、**14** 项部分对齐、**0** 项待实现。
+
+## 总览
+
+| 能力 | 权威入口 | Android 在线 | Android 离线 | Android 独立 Agent | 状态 |
+|---|---|---|---|---|---|
+| `assistant.workspace` | workspace assistant stream / MobileWorkspaceAgent | 调用 PC 权威接口 | 明确阻止 | 明确降级实现 | 部分对齐 |
+| `authoring.chapter` | /api/v1/projects/{project_id}/chapters | 调用 PC 权威接口 | 修订队列回放 | 修订队列回放 | 已对齐 |
+| `authoring.character` | /api/v1/projects/{project_id}/characters | 调用 PC 权威接口 | 修订队列回放 | 修订队列回放 | 已对齐 |
+| `authoring.outline` | /api/v1/projects/{project_id}/outline | 调用 PC 权威接口 | 修订队列回放 | 修订队列回放 | 已对齐 |
+| `authoring.project` | /api/v1/projects/{project_id} | 调用 PC 权威接口 | 修订队列回放 | 修订队列回放 | 已对齐 |
+| `authoring.worldbuilding` | /api/v1/projects/{project_id}/worldbuilding | 调用 PC 权威接口 | 修订队列回放 | 修订队列回放 | 已对齐 |
+| `chapter.history` | GET /chapters/{chapter_id}/snapshots[/diff/{snapshot_id}] | 调用 PC 只读接口 | 明确阻止 | 尚未支持 | 部分对齐 |
+| `chapter.reorder` | PUT /api/v1/projects/{project_id}/chapters/reorder | 调用 PC 权威接口 | 明确阻止 | 明确阻止 | 已对齐 |
+| `chapter.restore` | POST /chapters/{chapter_id}/restore/{snapshot_id} | 调用 PC 权威接口 | 明确阻止 | 明确阻止 | 已对齐 |
+| `character.ai_config` | GET/PUT /characters/{character_id}/ai-config | 调用 PC 权威接口 | 修订队列回放 | 尚未支持 | 部分对齐 |
+| `character.relationships` | GET /characters/relationships; PUT /characters/{character_id}/relationships | 调用 PC 权威接口 | 修订队列回放 | 明确降级实现 | 部分对齐 |
+| `character.versions` | GET /characters/{character_id}/versions[/{version_id}] | 调用 PC 只读接口 | 明确阻止 | 尚未支持 | 部分对齐 |
+| `context.preview` | preview_writing_context | 调用 PC 权威接口 | 明确阻止 | 明确降级实现 | 部分对齐 |
+| `governance.items` | /narrative-governance/items[/{type}/{id}] | 调用 PC 权威接口 | 修订队列回放 | 明确降级实现 | 部分对齐 |
+| `novel_creation.session` | /api/v1/novel-creation/* | 调用 PC 权威接口 | 本地副本 | 明确降级实现 | 部分对齐 |
+| `sync.conflicts` | POST /api/v1/sync/conflicts/{conflict_id}/resolve | 调用 PC 权威接口 | 明确阻止 | 不适用 | 已对齐 |
+| `sync.replication` | /api/v1/sync/{bootstrap,push,pull} | 调用 PC 权威接口 | 本地副本 | 本地副本 | 已对齐 |
+| `worldbuilding.history` | GET /worldbuilding/{entry_id}/{versions\|timeline} | 调用 PC 只读接口 | 明确阻止 | 尚未支持 | 部分对齐 |
+| `worldbuilding.relationships` | WorldbuildingRelation sync record | 修订队列回放 | 修订队列回放 | 尚未支持 | 部分对齐 |
+| `writer.chapter` | chapter_writer | 调用 PC 权威接口 | 明确阻止 | 明确降级实现 | 部分对齐 |
+| `writer.character` | character_writer | 调用 PC 权威接口 | 明确阻止 | 明确降级实现 | 部分对齐 |
+| `writer.outline` | outline_writer | 调用 PC 权威接口 | 明确阻止 | 明确降级实现 | 部分对齐 |
+| `writer.worldbuilding` | worldbuilding_writer | 调用 PC 权威接口 | 明确阻止 | 明确降级实现 | 部分对齐 |
+
+## 详细能力
+
+### `assistant.workspace` — 统一的工作区 Agent 对话与工具循环
+
+- **权威入口：** `workspace assistant stream / MobileWorkspaceAgent`（`pc_workspace_tool`）
+- **状态：** 部分对齐
+- **副作用：** 无写入副作用
+- **幂等策略：** `not_applicable`；只读或无需防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：没有 Gateway 且未配置手机直连模型时不启动 Agent。
+- **Android 独立 Agent：** 明确降级实现：共享生成后的提示词与工具 schema，但工具执行、上下文选择和审计仍是 Android 本地实现。
+- **已知缺口：**
+  - 手机独立 Agent 尚未共享 PC 的 ContextManifest、运行日志和完整恢复语义。
+
+### `authoring.chapter` — 章节创建、读取、更新和删除
+
+- **权威入口：** `/api/v1/projects/{project_id}/chapters`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** chapter_snapshot、narrative_checkpoint、cataloging、content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 修订队列回放：先写本地副本与 outbox，连接 PC 后由领域服务回放。
+
+### `authoring.character` — 角色卡创建、读取、更新和删除
+
+- **权威入口：** `/api/v1/projects/{project_id}/characters`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** character_version、alias_sync、content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 修订队列回放：本地写入统一投影为 PC Character 公共契约。
+
+### `authoring.outline` — 大纲节点创建、读取和更新
+
+- **权威入口：** `/api/v1/projects/{project_id}/outline`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** cycle_validation、character_link_replace、content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 修订队列回放
+
+### `authoring.project` — 作品资料读取与更新
+
+- **权威入口：** `/api/v1/projects/{project_id}`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 修订队列回放
+
+### `authoring.worldbuilding` — 世界观条目创建、读取、更新和删除
+
+- **权威入口：** `/api/v1/projects/{project_id}/worldbuilding`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** world_version、content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 修订队列回放
+
+### `chapter.history` — 章节快照列表、详情与差异比较
+
+- **权威入口：** `GET /chapters/{chapter_id}/snapshots[/diff/{snapshot_id}]`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** 无写入副作用
+- **幂等策略：** `read_only`；只读或无需防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 只读接口
+- **Android 离线：** 明确阻止：高级历史页面明确要求连接 PC Gateway，避免把不完整缓存当作权威版本。
+- **Android 独立 Agent：** 尚未支持：手机独立 Agent 不维护 PC 版本账本。
+- **已知缺口：**
+  - 离线副本中即使存在历史记录也不会开放恢复或 diff，以免版本链不完整。
+
+### `chapter.reorder` — 章节权威阅读顺序重排
+
+- **权威入口：** `PUT /api/v1/projects/{project_id}/chapters/reorder`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** authoritative_reorder、content_sync
+- **幂等策略：** `set_replacement`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：排序必须一次提交当前作品全部章节，离线副本不能猜测 authoritative sort_order。
+- **Android 独立 Agent：** 明确阻止：独立 Agent 不直接改变 PC 权威章节顺序。
+
+### `chapter.restore` — 从历史快照恢复章节及关联叙事状态
+
+- **权威入口：** `POST /chapters/{chapter_id}/restore/{snapshot_id}`（`pc_http`）
+- **状态：** 已对齐
+- **副作用：** chapter_restore、chapter_snapshot、ledger_restore、governance_invalidation、cataloging、content_sync
+- **幂等策略：** `client_serialization`；必须防重
+- **幂等限制：** Android 已串行化恢复并阻止重复点击；PC 恢复接口每次调用仍会创建一个新 restore 版本，后续应增加服务端 request key。
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：恢复会创建新版本并恢复 ledger，必须连接 PC。
+- **Android 独立 Agent：** 明确阻止：独立 Agent 不具备 PC ledger/checkpoint 权威数据。
+
+### `character.ai_config` — 角色专用语气、口头禅与模型配置
+
+- **权威入口：** `GET/PUT /characters/{character_id}/ai-config`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 尚未支持：手机独立 Agent 不消费 CharacterAIConfig；普通章节写作明确避免错误注入。
+- **已知缺口：**
+  - CharacterAIConfig 仅在连接 PC 的高级页面和同步回放中可用，尚未接入手机独立角色扮演能力。
+
+### `character.relationships` — 有方向的角色关系网读取与替换
+
+- **权威入口：** `GET /characters/relationships; PUT /characters/{character_id}/relationships`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** relationship_replace、content_sync
+- **幂等策略：** `set_replacement`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放：离线以单条有向边回放，不模拟在线“替换当前角色全部关系”的事务。
+- **Android 独立 Agent：** 明确降级实现：能消费缓存关系并写入创作上下文，但没有离线专用完整关系网编辑器。
+- **已知缺口：**
+  - 手机在线编辑复用 PC 全量替换接口；离线回放仍是逐边 upsert，事务语义不同。
+
+### `character.versions` — 角色版本列表与历史快照查看
+
+- **权威入口：** `GET /characters/{character_id}/versions[/{version_id}]`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** 无写入副作用
+- **幂等策略：** `read_only`；只读或无需防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 只读接口
+- **Android 离线：** 明确阻止：离线列表可能缺少完整历史，界面不把缓存冒充权威版本。
+- **Android 独立 Agent：** 尚未支持：独立 Agent 不维护角色版本账本。
+- **已知缺口：**
+  - Android 当前只读查看，尚未提供角色历史恢复。
+
+### `context.preview` — 写章前上下文预检
+
+- **权威入口：** `preview_writing_context`（`pc_workspace_tool`）
+- **状态：** 部分对齐
+- **副作用：** 无写入副作用
+- **幂等策略：** `read_only`；只读或无需防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口：通过 PC workspace assistant 调用同一工具。
+- **Android 离线：** 明确阻止：没有模型执行路由时只保留资料缓存，不运行上下文预检。
+- **Android 独立 Agent：** 明确降级实现：角色、关系和治理优先级已复刻，但没有 PC RAG、FTS、ContextManifest、source hash 和预算覆盖判定。
+- **已知缺口：**
+  - 手机独立预检仍是 Kotlin 近似实现，下一阶段应改为版本化 ContextManifest 契约。
+
+### `governance.items` — 伏笔、叙事债务及生命周期状态操作
+
+- **权威入口：** `/narrative-governance/items[/{type}/{id}]`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** governance_transition、content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 明确降级实现：可读取最新治理锁并用于写章，但独立 Agent 未开放治理项创建、复检和关闭工具。
+- **已知缺口：**
+  - 手机独立 Agent 目前只消费治理锁，不执行治理生命周期命令。
+
+### `novel_creation.session` — 对话式立项会话、阶段确认和正式归档
+
+- **权威入口：** `/api/v1/novel-creation/*`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** project_archive、structured_entities、content_sync
+- **幂等策略：** `request_key`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 本地副本：会话先保存在手机，正式归档后进入规范同步。
+- **Android 独立 Agent：** 明确降级实现：共享 PC 提示词、阶段规范和基线夹具，但运行状态机、恢复与并发控制仍是手机实现。
+- **已知缺口：**
+  - 手机独立立项尚未完全复用 PC 的运行记录、暂停/恢复和操作幂等状态机。
+
+### `sync.conflicts` — 同步冲突查看与用户选择解决
+
+- **权威入口：** `POST /api/v1/sync/conflicts/{conflict_id}/resolve`（`pc_sync_protocol`）
+- **状态：** 已对齐
+- **副作用：** conflict_resolution、sync_cursor
+- **幂等策略：** `server_transaction`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：冲突选择必须读取服务端当前分支。
+- **Android 独立 Agent：** 不适用：未连接 Gateway 时没有远端冲突可解决。
+
+### `sync.replication` — 修订、outbox、bootstrap、push/pull 和 tombstone 同步
+
+- **权威入口：** `/api/v1/sync/{bootstrap,push,pull}`（`pc_sync_protocol`）
+- **状态：** 已对齐
+- **副作用：** revision_order、tombstone、conflict_detection、sync_cursor
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 本地副本：本地修订和 tombstone 保存在 Room/outbox。
+- **Android 独立 Agent：** 本地副本：Agent 写入同一副本/outbox。
+
+### `worldbuilding.history` — 世界观版本与时间线查看
+
+- **权威入口：** `GET /worldbuilding/{entry_id}/{versions|timeline}`（`pc_http`）
+- **状态：** 部分对齐
+- **副作用：** 无写入副作用
+- **幂等策略：** `read_only`；只读或无需防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 只读接口
+- **Android 离线：** 明确阻止：历史入口要求完整 PC 版本链。
+- **Android 独立 Agent：** 尚未支持：手机独立 Agent 不维护世界观版本和时间线账本。
+- **已知缺口：**
+  - Android 当前只读查看，尚未提供世界观历史恢复。
+
+### `worldbuilding.relationships` — 世界观条目之间的结构化关系边
+
+- **权威入口：** `WorldbuildingRelation sync record`（`pc_sync_protocol`）
+- **状态：** 部分对齐
+- **副作用：** content_sync
+- **幂等策略：** `revisioned_outbox`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 修订队列回放：当前没有专用 PC HTTP 编辑路由，在线写入仍走同步契约。
+- **Android 离线：** 修订队列回放
+- **Android 独立 Agent：** 尚未支持：世界观写作上下文尚未消费 WorldbuildingRelation。
+- **已知缺口：**
+  - PC 尚无世界观关系专用 HTTP 领域命令；手机独立写作也尚未消费关系边。
+
+### `writer.chapter` — 根据大纲和受治理上下文生成章节草稿
+
+- **权威入口：** `chapter_writer`（`pc_workspace_tool`）
+- **状态：** 部分对齐
+- **副作用：** draft_store
+- **幂等策略：** `draft_reference`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：无模型执行路由时只编辑资料，不生成正文。
+- **Android 独立 Agent：** 明确降级实现：共享章节提示词并消费角色关系/治理锁，但未使用 ContextManifest、RAG、source hash、预算和 stale 校验。
+- **已知缺口：**
+  - 手机独立写章是当前最大语义差距，下一阶段必须共享 ContextManifest 选择和审计契约。
+
+### `writer.character` — 根据作品与世界观生成结构化角色卡
+
+- **权威入口：** `character_writer`（`pc_workspace_tool`）
+- **状态：** 部分对齐
+- **副作用：** draft_store
+- **幂等策略：** `draft_reference`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：没有手机直连模型时不运行生成器。
+- **Android 独立 Agent：** 明确降级实现：提示词和输出工具由 PC 构建时导出，但上下文检索和后续领域副作用在手机端执行。
+- **已知缺口：**
+  - 手机独立生成器尚未绑定 PC ContextManifest 和运行审计。
+
+### `writer.outline` — 生成结构化大纲节点
+
+- **权威入口：** `outline_writer`（`pc_workspace_tool`）
+- **状态：** 部分对齐
+- **副作用：** draft_store
+- **幂等策略：** `draft_reference`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：没有手机直连模型时不运行生成器。
+- **Android 独立 Agent：** 明确降级实现：提示词和输出工具共享，批次限制与本地上下文选择仍由 Kotlin 实现。
+- **已知缺口：**
+  - 手机独立生成器尚未绑定 PC ContextManifest 和运行审计。
+
+### `writer.worldbuilding` — 生成结构化世界观条目
+
+- **权威入口：** `worldbuilding_writer`（`pc_workspace_tool`）
+- **状态：** 部分对齐
+- **副作用：** draft_store
+- **幂等策略：** `draft_reference`；必须防重
+- **PC：** PC 权威实现
+- **Android 在线：** 调用 PC 权威接口
+- **Android 离线：** 明确阻止：没有手机直连模型时不运行生成器。
+- **Android 独立 Agent：** 明确降级实现：提示词和输出工具共享，但未消费世界观关系边，也没有 PC 上下文清单审计。
+- **已知缺口：**
+  - 手机独立世界观生成尚未消费 WorldbuildingRelation 或 ContextManifest。
+
+## 维护规则
+
+1. 新增 `PcApiPaths` 方法、`PcAuthoringContract` 可写类型或 `MobileWorkspaceAgent` 工具时，必须在契约中做出能力归属或写明忽略理由。
+2. 声称已实现的模式必须引用实际源码；每项能力必须引用至少一个回归测试。
+3. `degraded`、`unsupported` 或高风险写操作必须明确限制和幂等策略，不能以“行为大致相同”代替契约。
+4. 修改契约后运行：`python scripts/check-mobile-pc-parity.py --write-doc docs/mobile-pc-parity.md`。

--- a/scripts/check-mobile-pc-parity.py
+++ b/scripts/check-mobile-pc-parity.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Validate and render the Android ↔ PC capability parity contract.
+
+The contract is intentionally source-backed.  Every implemented claim must
+point at the PC authority, Android adapter, or regression test that proves it.
+Coverage extractors also fail when a new Android PC route, writable entity, or
+standalone workspace tool is added without an explicit parity decision.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT = ROOT / "contracts" / "mobile-pc-parity.json"
+DEFAULT_DOC = ROOT / "docs" / "mobile-pc-parity.md"
+
+MODES = ("pc", "android_online", "android_offline", "android_standalone")
+SUPPORT_STATES = {
+    "canonical",
+    "canonical_proxy",
+    "read_only_proxy",
+    "sync_replay",
+    "read_only_cache",
+    "local_cache",
+    "degraded",
+    "blocked",
+    "unsupported",
+    "not_applicable",
+}
+IMPLEMENTED_STATES = {
+    "canonical",
+    "canonical_proxy",
+    "read_only_proxy",
+    "sync_replay",
+    "read_only_cache",
+    "local_cache",
+    "degraded",
+}
+STATUS_STATES = {"aligned", "partial", "planned"}
+AUTHORITY_TYPES = {
+    "pc_http",
+    "pc_workspace_tool",
+    "pc_sync_protocol",
+    "pc_domain_service",
+    "shared_generated_contract",
+}
+IDEMPOTENCY_STRATEGIES = {
+    "read_only",
+    "server_transaction",
+    "revisioned_outbox",
+    "set_replacement",
+    "client_serialization",
+    "draft_reference",
+    "request_key",
+    "not_applicable",
+}
+AREAS = {
+    "assistant",
+    "authoring",
+    "chapter",
+    "character",
+    "context",
+    "governance",
+    "novel_creation",
+    "outline",
+    "sync",
+    "worldbuilding",
+}
+DESTRUCTIVE_SIDE_EFFECTS = {
+    "chapter_restore",
+    "relationship_replace",
+    "governance_transition",
+    "authoritative_reorder",
+}
+
+SUPPORT_LABELS = {
+    "canonical": "PC 权威实现",
+    "canonical_proxy": "调用 PC 权威接口",
+    "read_only_proxy": "调用 PC 只读接口",
+    "sync_replay": "修订队列回放",
+    "read_only_cache": "只读缓存",
+    "local_cache": "本地副本",
+    "degraded": "明确降级实现",
+    "blocked": "明确阻止",
+    "unsupported": "尚未支持",
+    "not_applicable": "不适用",
+}
+STATUS_LABELS = {
+    "aligned": "已对齐",
+    "partial": "部分对齐",
+    "planned": "待实现",
+}
+MODE_LABELS = {
+    "pc": "PC",
+    "android_online": "Android 在线",
+    "android_offline": "Android 离线",
+    "android_standalone": "Android 独立 Agent",
+}
+
+
+class ContractError(RuntimeError):
+    pass
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ContractError(message)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ContractError(f"missing contract: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ContractError(f"invalid JSON in {path}: {exc}") from exc
+    _require(isinstance(data, dict), "contract root must be an object")
+    return data
+
+
+def _read_source(root: Path, relative: str, cache: dict[str, str]) -> str:
+    _require(relative and not relative.startswith("/"), f"invalid source path: {relative!r}")
+    _require(".." not in Path(relative).parts, f"source path escapes repository: {relative}")
+    if relative not in cache:
+        path = root / relative
+        _require(path.is_file(), f"source path does not exist: {relative}")
+        cache[relative] = path.read_text(encoding="utf-8")
+    return cache[relative]
+
+
+def _validate_ref(
+    root: Path,
+    ref: Any,
+    *,
+    label: str,
+    cache: dict[str, str],
+) -> None:
+    _require(isinstance(ref, dict), f"{label} must be an object")
+    path = ref.get("path")
+    _require(isinstance(path, str) and path.strip(), f"{label}.path is required")
+    text = _read_source(root, path, cache)
+    contains = ref.get("contains")
+    if contains is None:
+        return
+    _require(isinstance(contains, str) and contains, f"{label}.contains must be non-empty")
+    minimum = ref.get("min_count", 1)
+    _require(isinstance(minimum, int) and minimum >= 1, f"{label}.min_count must be >= 1")
+    actual = text.count(contains)
+    _require(
+        actual >= minimum,
+        f"{label} expected {path!r} to contain {contains!r} at least {minimum} time(s); found {actual}",
+    )
+
+
+def _extract_symbols(target: dict[str, Any], text: str) -> set[str]:
+    extractor = target.get("extractor")
+    start_marker = target.get("start_marker")
+    end_marker = target.get("end_marker")
+    window = text
+    if start_marker:
+        start = text.find(start_marker)
+        _require(start >= 0, f"coverage target {target.get('id')} missing start_marker")
+        window = text[start:]
+    if end_marker:
+        end = window.find(end_marker, len(start_marker or ""))
+        _require(end >= 0, f"coverage target {target.get('id')} missing end_marker")
+        window = window[:end]
+
+    if extractor == "kotlin_functions":
+        return set(
+            re.findall(
+                r"^\s*(?:(?:internal|private|public)\s+)?fun\s+(\w+)\s*\(",
+                window,
+                flags=re.MULTILINE,
+            )
+        )
+    if extractor == "kotlin_map_list_keys":
+        return set(
+            re.findall(
+                r'^\s*"([a-z_]+)"\s+to\s+listOf\(',
+                window,
+                flags=re.MULTILINE,
+            )
+        )
+    if extractor == "kotlin_when_strings":
+        return set(re.findall(r'"([^"]+)"\s*->', window))
+    raise ContractError(f"unsupported coverage extractor: {extractor!r}")
+
+
+def _validate_coverage(
+    root: Path,
+    coverage: Any,
+    capability_ids: set[str],
+    cache: dict[str, str],
+) -> None:
+    _require(isinstance(coverage, list) and coverage, "coverage_targets must be a non-empty array")
+    target_ids: set[str] = set()
+    for index, target in enumerate(coverage):
+        label = f"coverage_targets[{index}]"
+        _require(isinstance(target, dict), f"{label} must be an object")
+        target_id = target.get("id")
+        _require(isinstance(target_id, str) and target_id, f"{label}.id is required")
+        _require(target_id not in target_ids, f"duplicate coverage target id: {target_id}")
+        target_ids.add(target_id)
+        path = target.get("path")
+        _require(isinstance(path, str) and path, f"{label}.path is required")
+        text = _read_source(root, path, cache)
+        extracted = _extract_symbols(target, text)
+        mapping = target.get("symbols")
+        ignored = target.get("ignore_symbols", {})
+        _require(isinstance(mapping, dict), f"{label}.symbols must be an object")
+        _require(isinstance(ignored, dict), f"{label}.ignore_symbols must be an object")
+        mapped_symbols = set(mapping)
+        ignored_symbols = set(ignored)
+        for symbol, capability_id in mapping.items():
+            _require(
+                capability_id in capability_ids,
+                f"{label}.symbols[{symbol!r}] references unknown capability {capability_id!r}",
+            )
+        for symbol, reason in ignored.items():
+            _require(isinstance(reason, str) and reason.strip(), f"{label}.ignore_symbols[{symbol!r}] needs a reason")
+        missing_decisions = extracted - mapped_symbols - ignored_symbols
+        stale_decisions = (mapped_symbols | ignored_symbols) - extracted
+        _require(
+            not missing_decisions,
+            f"{target_id} has uncovered source symbols: {sorted(missing_decisions)}",
+        )
+        _require(
+            not stale_decisions,
+            f"{target_id} lists source symbols that no longer exist: {sorted(stale_decisions)}",
+        )
+
+
+def validate_contract(root: Path, data: dict[str, Any]) -> list[dict[str, Any]]:
+    _require(data.get("schema_version") == 1, "schema_version must be 1")
+    contract_version = data.get("contract_version")
+    _require(
+        isinstance(contract_version, str)
+        and re.fullmatch(r"\d{4}-\d{2}-\d{2}", contract_version),
+        "contract_version must use YYYY-MM-DD",
+    )
+    _require(data.get("canonical_authority") == "pc", "canonical_authority must be 'pc'")
+    mode_definitions = data.get("modes")
+    _require(isinstance(mode_definitions, dict), "modes must be an object")
+    _require(set(mode_definitions) == set(MODES), f"modes must contain exactly {list(MODES)}")
+    _require(
+        all(isinstance(value, str) and value.strip() for value in mode_definitions.values()),
+        "every mode definition must be non-empty text",
+    )
+    capabilities = data.get("capabilities")
+    _require(isinstance(capabilities, list) and capabilities, "capabilities must be a non-empty array")
+    ids = [item.get("id") for item in capabilities if isinstance(item, dict)]
+    _require(len(ids) == len(capabilities), "every capability must be an object with an id")
+    _require(all(isinstance(item, str) and item for item in ids), "capability ids must be non-empty strings")
+    _require(len(ids) == len(set(ids)), "capability ids must be unique")
+    _require(ids == sorted(ids), "capabilities must be sorted by id")
+
+    cache: dict[str, str] = {}
+    for index, capability in enumerate(capabilities):
+        capability_id = capability["id"]
+        label = f"capabilities[{index}] ({capability_id})"
+        _require(capability.get("area") in AREAS, f"{label}.area is invalid")
+        _require(isinstance(capability.get("summary"), str) and capability["summary"].strip(), f"{label}.summary is required")
+        status = capability.get("status")
+        _require(status in STATUS_STATES, f"{label}.status is invalid")
+
+        authority = capability.get("authority")
+        _require(isinstance(authority, dict), f"{label}.authority must be an object")
+        _require(authority.get("type") in AUTHORITY_TYPES, f"{label}.authority.type is invalid")
+        _require(isinstance(authority.get("entrypoint"), str) and authority["entrypoint"].strip(), f"{label}.authority.entrypoint is required")
+        authority_refs = authority.get("source_refs")
+        _require(isinstance(authority_refs, list) and authority_refs, f"{label}.authority.source_refs is required")
+        for ref_index, ref in enumerate(authority_refs):
+            _validate_ref(root, ref, label=f"{label}.authority.source_refs[{ref_index}]", cache=cache)
+
+        modes = capability.get("modes")
+        _require(isinstance(modes, dict), f"{label}.modes must be an object")
+        _require(set(modes) == set(MODES), f"{label}.modes must contain exactly {list(MODES)}")
+        _require(
+            modes["pc"].get("support") == "canonical",
+            f"{label}.modes.pc must be canonical",
+        )
+        has_gap = False
+        for mode in MODES:
+            mode_data = modes[mode]
+            mode_label = f"{label}.modes.{mode}"
+            _require(isinstance(mode_data, dict), f"{mode_label} must be an object")
+            support = mode_data.get("support")
+            _require(support in SUPPORT_STATES, f"{mode_label}.support is invalid")
+            refs = mode_data.get("source_refs", [])
+            _require(isinstance(refs, list), f"{mode_label}.source_refs must be an array")
+            if support in IMPLEMENTED_STATES and not (mode == "pc" and support == "canonical"):
+                _require(refs, f"{mode_label} claims {support!r} without source_refs")
+            for ref_index, ref in enumerate(refs):
+                _validate_ref(root, ref, label=f"{mode_label}.source_refs[{ref_index}]", cache=cache)
+            if support in {"blocked", "unsupported", "not_applicable"}:
+                _require(
+                    isinstance(mode_data.get("reason"), str) and mode_data["reason"].strip(),
+                    f"{mode_label}.reason is required for {support}",
+                )
+            if support == "degraded":
+                _require(
+                    isinstance(mode_data.get("limitations"), str) and mode_data["limitations"].strip(),
+                    f"{mode_label}.limitations is required for degraded support",
+                )
+            if support in {"degraded", "unsupported"}:
+                has_gap = True
+
+        if has_gap:
+            _require(status in {"partial", "planned"}, f"{label} has a parity gap but status is {status!r}")
+            gaps = capability.get("known_gaps")
+            _require(isinstance(gaps, list) and gaps, f"{label}.known_gaps is required")
+            _require(all(isinstance(item, str) and item.strip() for item in gaps), f"{label}.known_gaps must contain text")
+        elif status == "aligned":
+            _require(not capability.get("known_gaps"), f"{label} is aligned but still declares known_gaps")
+
+        side_effects = capability.get("side_effects")
+        _require(isinstance(side_effects, list), f"{label}.side_effects must be an array")
+        _require(len(side_effects) == len(set(side_effects)), f"{label}.side_effects contains duplicates")
+        _require(all(isinstance(item, str) and item for item in side_effects), f"{label}.side_effects must contain strings")
+
+        idempotency = capability.get("idempotency")
+        _require(isinstance(idempotency, dict), f"{label}.idempotency must be an object")
+        required = idempotency.get("required")
+        _require(isinstance(required, bool), f"{label}.idempotency.required must be boolean")
+        strategy = idempotency.get("strategy")
+        _require(strategy in IDEMPOTENCY_STRATEGIES, f"{label}.idempotency.strategy is invalid")
+        if required:
+            _require(strategy != "not_applicable", f"{label} requires idempotency but has no strategy")
+        if DESTRUCTIVE_SIDE_EFFECTS.intersection(side_effects):
+            _require(required, f"{label} has destructive side effects and must require idempotency")
+        if strategy == "client_serialization":
+            _require(
+                isinstance(idempotency.get("limitations"), str) and idempotency["limitations"].strip(),
+                f"{label}.idempotency.limitations is required for client_serialization",
+            )
+
+        tests = capability.get("tests")
+        _require(isinstance(tests, list) and tests, f"{label}.tests must be a non-empty array")
+        for ref_index, ref in enumerate(tests):
+            _validate_ref(root, ref, label=f"{label}.tests[{ref_index}]", cache=cache)
+
+    _validate_coverage(root, data.get("coverage_targets"), set(ids), cache)
+    return capabilities
+
+
+def _mode_text(mode: dict[str, Any]) -> str:
+    support = mode["support"]
+    text = SUPPORT_LABELS[support]
+    detail = mode.get("reason") or mode.get("limitations") or mode.get("notes")
+    if detail:
+        text += f"：{detail}"
+    return text
+
+
+def render_markdown(data: dict[str, Any], capabilities: list[dict[str, Any]]) -> str:
+    aligned_count = sum(item["status"] == "aligned" for item in capabilities)
+    partial_count = sum(item["status"] == "partial" for item in capabilities)
+    planned_count = sum(item["status"] == "planned" for item in capabilities)
+    lines = [
+        "# Android ↔ PC 能力对齐契约",
+        "",
+        "> 本文由 `contracts/mobile-pc-parity.json` 通过 `scripts/check-mobile-pc-parity.py` 生成；请勿手工修改。",
+        "",
+        "PC 是小说数据、领域副作用和上下文治理的唯一权威实现。Android 在线模式应尽量作为薄客户端；离线模式只允许可验证回放的修订；手机独立 Agent 的降级能力必须显式记录。",
+        "",
+        f"当前共登记 **{len(capabilities)}** 项能力：**{aligned_count}** 项已对齐、**{partial_count}** 项部分对齐、**{planned_count}** 项待实现。",
+        "",
+        "## 总览",
+        "",
+        "| 能力 | 权威入口 | Android 在线 | Android 离线 | Android 独立 Agent | 状态 |",
+        "|---|---|---|---|---|---|",
+    ]
+    for item in capabilities:
+        lines.append(
+            "| `{}` | {} | {} | {} | {} | {} |".format(
+                item["id"],
+                item["authority"]["entrypoint"].replace("|", "\\|"),
+                SUPPORT_LABELS[item["modes"]["android_online"]["support"]],
+                SUPPORT_LABELS[item["modes"]["android_offline"]["support"]],
+                SUPPORT_LABELS[item["modes"]["android_standalone"]["support"]],
+                STATUS_LABELS[item["status"]],
+            )
+        )
+
+    lines.extend(["", "## 详细能力", ""])
+    for item in capabilities:
+        lines.extend(
+            [
+                f"### `{item['id']}` — {item['summary']}",
+                "",
+                f"- **权威入口：** `{item['authority']['entrypoint']}`（`{item['authority']['type']}`）",
+                f"- **状态：** {STATUS_LABELS[item['status']]}",
+                f"- **副作用：** {('、'.join(item['side_effects']) if item['side_effects'] else '无写入副作用')}",
+                f"- **幂等策略：** `{item['idempotency']['strategy']}`；{'必须防重' if item['idempotency']['required'] else '只读或无需防重'}",
+            ]
+        )
+        if item["idempotency"].get("limitations"):
+            lines.append(f"- **幂等限制：** {item['idempotency']['limitations']}")
+        for mode in MODES:
+            lines.append(f"- **{MODE_LABELS[mode]}：** {_mode_text(item['modes'][mode])}")
+        if item.get("known_gaps"):
+            lines.append("- **已知缺口：**")
+            lines.extend(f"  - {gap}" for gap in item["known_gaps"])
+        lines.append("")
+
+    lines.extend(
+        [
+            "## 维护规则",
+            "",
+            "1. 新增 `PcApiPaths` 方法、`PcAuthoringContract` 可写类型或 `MobileWorkspaceAgent` 工具时，必须在契约中做出能力归属或写明忽略理由。",
+            "2. 声称已实现的模式必须引用实际源码；每项能力必须引用至少一个回归测试。",
+            "3. `degraded`、`unsupported` 或高风险写操作必须明确限制和幂等策略，不能以“行为大致相同”代替契约。",
+            "4. 修改契约后运行：`python scripts/check-mobile-pc-parity.py --write-doc docs/mobile-pc-parity.md`。",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--check-doc", type=Path)
+    parser.add_argument("--write-doc", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    root = args.root.resolve()
+    contract_path = args.contract if args.contract.is_absolute() else root / args.contract
+    data = _load_json(contract_path)
+    capabilities = validate_contract(root, data)
+    rendered = render_markdown(data, capabilities)
+
+    if args.write_doc:
+        output = args.write_doc if args.write_doc.is_absolute() else root / args.write_doc
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    if args.check_doc:
+        expected = args.check_doc if args.check_doc.is_absolute() else root / args.check_doc
+        _require(expected.is_file(), f"generated parity document is missing: {expected}")
+        actual = expected.read_text(encoding="utf-8")
+        _require(
+            actual == rendered,
+            f"{expected.relative_to(root)} is stale; run: python scripts/check-mobile-pc-parity.py --write-doc {expected.relative_to(root)}",
+        )
+
+    print(f"mobile/PC parity contract valid: {len(capabilities)} capabilities")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ContractError as exc:
+        print(f"parity contract error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc


### PR DESCRIPTION
## 目标

把 Android 向 PC 对齐从人工约定升级为机器可校验的架构契约，避免后续新增 PC 路由、Android 写契约或手机独立 Agent 工具时再次静默漂移。

本 PR 已在 #30 合并后重建为基于 `main` 的单层提交，不再携带 #30 的历史差异。

## 已落地

- 新增 `contracts/mobile-pc-parity.json`，登记 23 项跨端能力。
- 对每项能力声明 PC 权威入口、Android 在线/离线/独立模式支持级别、领域副作用、幂等策略、源码证据和回归测试。
- 新增 `scripts/check-mobile-pc-parity.py`：
  - 校验所有能力声明及源码证据；
  - 检查 `PcApiPaths`、`PcAuthoringContract` 和 `MobileWorkspaceAgent` 新增符号是否完成对齐决策；
  - 自动生成并核对对齐文档。
- 新增生成文档 `docs/mobile-pc-parity.md`。
- 新增后端回归测试 `test_mobile_pc_parity_contract.py`。
- Architecture CI 在 Android、契约、文档或相关脚本变化时执行对齐门禁。

## 当前快照

- 23 项能力；
- 9 项已对齐；
- 14 项部分对齐；
- 0 项未分类待实现；
- 已明确记录手机独立 Agent 的 ContextManifest、审计、版本历史、AI Config、世界观关系等缺口。

## 验证

- `python scripts/check-mobile-pc-parity.py --check-doc docs/mobile-pc-parity.md`
- `pytest backend/tests/test_mobile_pc_parity_contract.py`
- `python -m compileall -q scripts/check-mobile-pc-parity.py backend/tests/test_mobile_pc_parity_contract.py`
- `git diff --check`
