### PR TITLE
让 Android 独立写章消费 PC ContextManifest

### DIFF
--- a/.github/workflows/architecture-ci.yml
+++ b/.github/workflows/architecture-ci.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/check-architecture.py"
       - "scripts/check-mobile-pc-parity.py"
       - "scripts/export-mobile-prompt-contract.py"
+      - "scripts/export-mobile-context-policy.py"
       - "scripts/run-performance-baseline.py"
       - ".jscpd.json"
       - ".github/workflows/architecture-ci.yml"
@@ -25,6 +26,7 @@ on:
       - "scripts/check-architecture.py"
       - "scripts/check-mobile-pc-parity.py"
       - "scripts/export-mobile-prompt-contract.py"
+      - "scripts/export-mobile-context-policy.py"
       - ".jscpd.json"
       - ".github/workflows/architecture-ci.yml"
 
@@ -59,6 +61,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Validate generated Android context policy
+        run: python scripts/export-mobile-context-policy.py --check
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/backend/app/services/mobile_context_policy.py
+++ b/backend/app/services/mobile_context_policy.py
@@ -1,0 +1,149 @@
+"""Portable projection of the PC writing ContextManifest policy.
+
+Thin clients consume this generated contract instead of maintaining a second
+set of context tiers, budget defaults, ranking weights, or stale rules.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .context_orchestrator import (
+    CONTEXT_INDEX_VERSION,
+    CONTEXT_POLICY_VERSION,
+    DEFAULT_CONTEXT_WINDOW_TOKENS,
+    DEFAULT_SAFETY_MARGIN_TOKENS,
+    TASK_CONTEXT_CONTRACTS,
+)
+
+
+def portable_context_policy(task_type: str = "writing") -> dict[str, Any]:
+    """Return deterministic context-selection rules safe to embed on Android.
+
+    PC-only capabilities (FTS, semantic embeddings, pinned chunks and durable
+    audit rows) are explicitly described as unavailable rather than silently
+    reimplemented with different semantics.
+    """
+    contract = TASK_CONTEXT_CONTRACTS[task_type]
+    return {
+        "schema_version": 1,
+        "policy_version": CONTEXT_POLICY_VERSION,
+        "index_version": CONTEXT_INDEX_VERSION,
+        "task_type": contract.task_type,
+        "contract": {
+            "required_categories": list(contract.required_categories),
+            "optional_categories": list(contract.optional_categories),
+        },
+        "model_defaults": {
+            "context_window_tokens": DEFAULT_CONTEXT_WINDOW_TOKENS,
+            "safety_margin_tokens": DEFAULT_SAFETY_MARGIN_TOKENS,
+            "minimum_output_reserve_tokens": 2_048,
+            "output_ratio": contract.output_ratio,
+        },
+        "categories": {
+            "style": {
+                "tier": 1,
+                "max_items": 1,
+                "required": "style" in contract.required_categories,
+                "source_type": "project_style",
+            },
+            "target_outline": {
+                "tier": 1,
+                "max_items": 1,
+                "required": "target_outline" in contract.required_categories,
+                "source_type": "outline",
+                "field_limit_chars": 1_200,
+            },
+            "user_requirement": {
+                "tier": 2,
+                "max_items": 1,
+                "required": False,
+                "source_type": "inline",
+                "content_limit_chars": 4_000,
+            },
+            "previous_summary": {
+                "tier": 3,
+                "max_items": 3,
+                "required": False,
+                "source_type": "chapter_summary",
+                "content_limit_chars": 1_600,
+            },
+            "scene_character": {
+                "tier": 3,
+                "max_items": 12,
+                "required": False,
+                "source_type": "character",
+                "content_limit_chars": 12_000,
+            },
+            "narrative_governance": {
+                "tier": 3,
+                "max_items": 1,
+                "required": False,
+                "source_type": "narrative_governance",
+                "content_limit_chars": 5_000,
+                "empty_ledger_text": "Narrative governance: no due or high-risk items.",
+            },
+            "hybrid_retrieval": {
+                "tier": 4,
+                "max_items": 24,
+                "required": False,
+                "content_limit_chars": 1_800,
+            },
+            "memory": {
+                "tier": 5,
+                "max_items": 6,
+                "required": False,
+                "source_type": "assistant_memory",
+                "content_limit_chars": 900,
+            },
+        },
+        "selection": {
+            "ordering": ["tier", "required_first", "score_desc", "title"],
+            "dedupe_identity": ["source_type", "source_id", "chunk_id"],
+            "required_over_budget_status": "needs_confirmation",
+            "unknown_model_uses_defaults": True,
+        },
+        "ranking": {
+            "hybrid": {
+                "lexical": 0.45,
+                "semantic": 0.35,
+                "recency": 0.15,
+                "structural": 0.05,
+            },
+            "lexical_fallback": {
+                "lexical": 0.70,
+                "recency": 0.20,
+                "structural": 0.10,
+            },
+        },
+        "token_estimation": {
+            "cjk_ranges": ["\\u4e00-\\u9fff", "\\u3400-\\u4dbf"],
+            "cjk_tokens_per_character": 1,
+            "non_cjk_characters_per_token": 4,
+            "minimum_non_cjk_tokens_for_non_empty_text": 1,
+        },
+        "hashing": {
+            "algorithm": "sha256",
+            "encoding": "utf-8",
+            "selected_content_hash": True,
+            "selection_fingerprint_fields": [
+                "category",
+                "source_type",
+                "source_id",
+                "chunk_id",
+                "source_hash",
+            ],
+        },
+        "mobile_projection": {
+            "execution_route": "android_standalone",
+            "retrieval": "deterministic_local_lexical_fallback",
+            "style_projection": "pc_prompt_contract_style_context",
+            "fts_available": False,
+            "semantic_embeddings_available": False,
+            "pinned_chunks_available": False,
+            "durable_manifest_audit_available": False,
+            "manifest_persistence": "session_only",
+            "stale_on_model_change": True,
+            "stale_on_request_change": True,
+            "stale_on_selected_source_change": True,
+        },
+    }

--- a/backend/tests/test_mobile_context_policy.py
+++ b/backend/tests/test_mobile_context_policy.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from app.services.mobile_context_policy import portable_context_policy
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ASSET = (
+    ROOT
+    / "mobile"
+    / "android"
+    / "app"
+    / "src"
+    / "main"
+    / "assets"
+    / "pc_context_manifest_policy.json"
+)
+EXPORTER = ROOT / "scripts" / "export-mobile-context-policy.py"
+
+
+def _exporter_module():
+    spec = importlib.util.spec_from_file_location("export_mobile_context_policy", EXPORTER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_android_context_policy_asset_is_generated_from_pc_source() -> None:
+    module = _exporter_module()
+    expected = module.build_policy()
+    actual = json.loads(ASSET.read_text(encoding="utf-8"))
+    assert actual == expected
+    assert len(actual["source_sha256"]) == 64
+
+
+def test_portable_writing_policy_keeps_pc_contract_and_budget() -> None:
+    policy = portable_context_policy("writing")
+    assert policy["contract"]["required_categories"] == ["target_outline", "style"]
+    assert policy["model_defaults"] == {
+        "context_window_tokens": 16_384,
+        "safety_margin_tokens": 512,
+        "minimum_output_reserve_tokens": 2_048,
+        "output_ratio": 0.45,
+    }
+    assert policy["categories"]["previous_summary"]["max_items"] == 3
+    assert policy["categories"]["scene_character"]["max_items"] == 12
+    assert policy["categories"]["hybrid_retrieval"]["max_items"] == 24
+
+
+def test_portable_policy_declares_ranking_hashing_and_android_degradation() -> None:
+    policy = portable_context_policy("writing")
+    assert policy["ranking"]["hybrid"] == {
+        "lexical": 0.45,
+        "semantic": 0.35,
+        "recency": 0.15,
+        "structural": 0.05,
+    }
+    assert policy["ranking"]["lexical_fallback"] == {
+        "lexical": 0.70,
+        "recency": 0.20,
+        "structural": 0.10,
+    }
+    assert policy["hashing"]["algorithm"] == "sha256"
+    assert policy["token_estimation"]["non_cjk_characters_per_token"] == 4
+    mobile = policy["mobile_projection"]
+    assert mobile["retrieval"] == "deterministic_local_lexical_fallback"
+    assert mobile["fts_available"] is False
+    assert mobile["semantic_embeddings_available"] is False
+    assert mobile["pinned_chunks_available"] is False
+    assert mobile["manifest_persistence"] == "session_only"

--- a/contracts/mobile-pc-parity.json
+++ b/contracts/mobile-pc-parity.json
@@ -143,9 +143,13 @@
             {
               "path": "scripts/export-mobile-prompt-contract.py",
               "contains": "MOBILE_TOOL_NAMES = ["
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextManifest.kt",
+              "contains": "internal class MobileContextManifestEngine("
             }
           ],
-          "limitations": "共享生成后的提示词与工具 schema，但工具执行、上下文选择和审计仍是 Android 本地实现。"
+          "limitations": "提示词、工具 schema 与版本化上下文策略均由 PC 源生成；Android 仍使用本地工具适配器、会话级 ContextManifest 和确定性词法降级，不具备 PC 的持久运行审计与完整恢复语义。"
         }
       },
       "side_effects": [],
@@ -164,7 +168,7 @@
         }
       ],
       "known_gaps": [
-        "手机独立 Agent 尚未共享 PC 的 ContextManifest、运行日志和完整恢复语义。"
+        "手机独立 Agent 尚未持久化运行日志和 ContextManifest，应用重启后的恢复仍弱于 PC。"
       ]
     },
     {
@@ -998,11 +1002,19 @@
               "contains": "private suspend fun previewWritingContext("
             },
             {
-              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextParity.kt",
-              "contains": "internal fun pcGovernanceContext("
+              "path": "backend/app/services/mobile_context_policy.py",
+              "contains": "def portable_context_policy("
+            },
+            {
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextManifest.kt",
+              "contains": "internal class MobileContextManifestEngine("
+            },
+            {
+              "path": "scripts/export-mobile-context-policy.py",
+              "contains": "def build_policy()"
             }
           ],
-          "limitations": "角色、关系和治理优先级已复刻，但没有 PC RAG、FTS、ContextManifest、source hash 和预算覆盖判定。"
+          "limitations": "已共享版本化策略、必选 coverage、全局 token 预算、source hash、选择指纹和 stale 校验；Android 独立模式仍以本地词法检索替代 PC FTS/向量检索，不支持 pinned chunks，且清单仅在会话内保存。"
         }
       },
       "side_effects": [],
@@ -1016,12 +1028,16 @@
           "contains": "test_preview_writing_context_returns_state_and_warnings"
         },
         {
-          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextParityTest.kt",
-          "contains": "governance context keeps only latest state per character"
+          "path": "backend/tests/test_mobile_context_policy.py",
+          "contains": "test_android_context_policy_asset_is_generated_from_pc_source"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt",
+          "contains": "selected source changes make a cached manifest stale"
         }
       ],
       "known_gaps": [
-        "手机独立预检仍是 Kotlin 近似实现，下一阶段应改为版本化 ContextManifest 契约。"
+        "手机独立预检尚未复用 PC 的 FTS、语义嵌入、pinned chunks 与数据库级 ContextManifest 审计。"
       ]
     },
     {
@@ -1504,11 +1520,15 @@
               "contains": "private suspend fun chapterWriter("
             },
             {
-              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextParity.kt",
-              "contains": "internal fun pcCharacterDetails("
+              "path": "mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextManifest.kt",
+              "contains": "fun validate(existing: MobileContextManifest"
+            },
+            {
+              "path": "mobile/android/app/src/main/assets/pc_context_manifest_policy.json",
+              "contains": "\"stale_on_selected_source_change\": true"
             }
           ],
-          "limitations": "共享章节提示词并消费角色关系/治理锁，但未使用 ContextManifest、RAG、source hash、预算和 stale 校验。"
+          "limitations": "写章前会创建或校验会话级 ContextManifest，并把必选锚点、预算、策略/请求/选择指纹写入草稿快照；检索仍为 Android 本地词法降级，清单和草稿审计尚未持久化到 PC 账本。"
         }
       },
       "side_effects": [
@@ -1524,12 +1544,16 @@
           "contains": "test_writing_manifest_consumes_full_character_card_and_relationships"
         },
         {
-          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextParityTest.kt",
-          "contains": "relationship preview uses PC names and selected endpoint semantics"
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt",
+          "contains": "missing target outline requires confirmation instead of writing blindly"
+        },
+        {
+          "path": "mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt",
+          "contains": "model changes make a cached manifest stale"
         }
       ],
       "known_gaps": [
-        "手机独立写章是当前最大语义差距，下一阶段必须共享 ContextManifest 选择和审计契约。"
+        "手机独立写章已具备 ContextManifest 防漂移门禁，但仍缺 PC 级持久审计、语义检索和跨重启恢复。"
       ]
     },
     {

--- a/docs/mobile-pc-parity.md
+++ b/docs/mobile-pc-parity.md
@@ -45,9 +45,9 @@ PC 是小说数据、领域副作用和上下文治理的唯一权威实现。An
 - **PC：** PC 权威实现
 - **Android 在线：** 调用 PC 权威接口
 - **Android 离线：** 明确阻止：没有 Gateway 且未配置手机直连模型时不启动 Agent。
-- **Android 独立 Agent：** 明确降级实现：共享生成后的提示词与工具 schema，但工具执行、上下文选择和审计仍是 Android 本地实现。
+- **Android 独立 Agent：** 明确降级实现：提示词、工具 schema 与版本化上下文策略均由 PC 源生成；Android 仍使用本地工具适配器、会话级 ContextManifest 和确定性词法降级，不具备 PC 的持久运行审计与完整恢复语义。
 - **已知缺口：**
-  - 手机独立 Agent 尚未共享 PC 的 ContextManifest、运行日志和完整恢复语义。
+  - 手机独立 Agent 尚未持久化运行日志和 ContextManifest，应用重启后的恢复仍弱于 PC。
 
 ### `authoring.chapter` — 章节创建、读取、更新和删除
 
@@ -188,9 +188,9 @@ PC 是小说数据、领域副作用和上下文治理的唯一权威实现。An
 - **PC：** PC 权威实现
 - **Android 在线：** 调用 PC 权威接口：通过 PC workspace assistant 调用同一工具。
 - **Android 离线：** 明确阻止：没有模型执行路由时只保留资料缓存，不运行上下文预检。
-- **Android 独立 Agent：** 明确降级实现：角色、关系和治理优先级已复刻，但没有 PC RAG、FTS、ContextManifest、source hash 和预算覆盖判定。
+- **Android 独立 Agent：** 明确降级实现：已共享版本化策略、必选 coverage、全局 token 预算、source hash、选择指纹和 stale 校验；Android 独立模式仍以本地词法检索替代 PC FTS/向量检索，不支持 pinned chunks，且清单仅在会话内保存。
 - **已知缺口：**
-  - 手机独立预检仍是 Kotlin 近似实现，下一阶段应改为版本化 ContextManifest 契约。
+  - 手机独立预检尚未复用 PC 的 FTS、语义嵌入、pinned chunks 与数据库级 ContextManifest 审计。
 
 ### `governance.items` — 伏笔、叙事债务及生命周期状态操作
 
@@ -275,9 +275,9 @@ PC 是小说数据、领域副作用和上下文治理的唯一权威实现。An
 - **PC：** PC 权威实现
 - **Android 在线：** 调用 PC 权威接口
 - **Android 离线：** 明确阻止：无模型执行路由时只编辑资料，不生成正文。
-- **Android 独立 Agent：** 明确降级实现：共享章节提示词并消费角色关系/治理锁，但未使用 ContextManifest、RAG、source hash、预算和 stale 校验。
+- **Android 独立 Agent：** 明确降级实现：写章前会创建或校验会话级 ContextManifest，并把必选锚点、预算、策略/请求/选择指纹写入草稿快照；检索仍为 Android 本地词法降级，清单和草稿审计尚未持久化到 PC 账本。
 - **已知缺口：**
-  - 手机独立写章是当前最大语义差距，下一阶段必须共享 ContextManifest 选择和审计契约。
+  - 手机独立写章已具备 ContextManifest 防漂移门禁，但仍缺 PC 级持久审计、语义检索和跨重启恢复。
 
 ### `writer.character` — 根据作品与世界观生成结构化角色卡
 

--- a/mobile/android/app/src/main/assets/pc_context_manifest_policy.json
+++ b/mobile/android/app/src/main/assets/pc_context_manifest_policy.json
@@ -1,0 +1,148 @@
+{
+  "categories": {
+    "hybrid_retrieval": {
+      "content_limit_chars": 1800,
+      "max_items": 24,
+      "required": false,
+      "tier": 4
+    },
+    "memory": {
+      "content_limit_chars": 900,
+      "max_items": 6,
+      "required": false,
+      "source_type": "assistant_memory",
+      "tier": 5
+    },
+    "narrative_governance": {
+      "content_limit_chars": 5000,
+      "empty_ledger_text": "Narrative governance: no due or high-risk items.",
+      "max_items": 1,
+      "required": false,
+      "source_type": "narrative_governance",
+      "tier": 3
+    },
+    "previous_summary": {
+      "content_limit_chars": 1600,
+      "max_items": 3,
+      "required": false,
+      "source_type": "chapter_summary",
+      "tier": 3
+    },
+    "scene_character": {
+      "content_limit_chars": 12000,
+      "max_items": 12,
+      "required": false,
+      "source_type": "character",
+      "tier": 3
+    },
+    "style": {
+      "max_items": 1,
+      "required": true,
+      "source_type": "project_style",
+      "tier": 1
+    },
+    "target_outline": {
+      "field_limit_chars": 1200,
+      "max_items": 1,
+      "required": true,
+      "source_type": "outline",
+      "tier": 1
+    },
+    "user_requirement": {
+      "content_limit_chars": 4000,
+      "max_items": 1,
+      "required": false,
+      "source_type": "inline",
+      "tier": 2
+    }
+  },
+  "contract": {
+    "optional_categories": [
+      "user_requirement",
+      "previous_summary",
+      "scene_character",
+      "worldbuilding",
+      "narrative_governance",
+      "memory",
+      "skill",
+      "hybrid_retrieval"
+    ],
+    "required_categories": [
+      "target_outline",
+      "style"
+    ]
+  },
+  "hashing": {
+    "algorithm": "sha256",
+    "encoding": "utf-8",
+    "selected_content_hash": true,
+    "selection_fingerprint_fields": [
+      "category",
+      "source_type",
+      "source_id",
+      "chunk_id",
+      "source_hash"
+    ]
+  },
+  "index_version": 1,
+  "mobile_projection": {
+    "durable_manifest_audit_available": false,
+    "execution_route": "android_standalone",
+    "fts_available": false,
+    "manifest_persistence": "session_only",
+    "pinned_chunks_available": false,
+    "retrieval": "deterministic_local_lexical_fallback",
+    "semantic_embeddings_available": false,
+    "stale_on_model_change": true,
+    "stale_on_request_change": true,
+    "stale_on_selected_source_change": true,
+    "style_projection": "pc_prompt_contract_style_context"
+  },
+  "model_defaults": {
+    "context_window_tokens": 16384,
+    "minimum_output_reserve_tokens": 2048,
+    "output_ratio": 0.45,
+    "safety_margin_tokens": 512
+  },
+  "policy_version": 1,
+  "ranking": {
+    "hybrid": {
+      "lexical": 0.45,
+      "recency": 0.15,
+      "semantic": 0.35,
+      "structural": 0.05
+    },
+    "lexical_fallback": {
+      "lexical": 0.7,
+      "recency": 0.2,
+      "structural": 0.1
+    }
+  },
+  "schema_version": 1,
+  "selection": {
+    "dedupe_identity": [
+      "source_type",
+      "source_id",
+      "chunk_id"
+    ],
+    "ordering": [
+      "tier",
+      "required_first",
+      "score_desc",
+      "title"
+    ],
+    "required_over_budget_status": "needs_confirmation",
+    "unknown_model_uses_defaults": true
+  },
+  "source_sha256": "d0645d13f836ede14981a28b5b0d93c5a2890710c2404c9fe0d3304fcfd28b88",
+  "task_type": "writing",
+  "token_estimation": {
+    "cjk_ranges": [
+      "\\u4e00-\\u9fff",
+      "\\u3400-\\u4dbf"
+    ],
+    "cjk_tokens_per_character": 1,
+    "minimum_non_cjk_tokens_for_non_empty_text": 1,
+    "non_cjk_characters_per_token": 4
+  }
+}

--- a/mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextManifest.kt
+++ b/mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileContextManifest.kt
@@ -1,0 +1,817 @@
+package com.siming.mobile.data.agent
+
+import android.content.Context
+import java.security.MessageDigest
+import java.util.UUID
+import kotlin.math.max
+import kotlin.math.min
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.put
+
+internal data class MobileContextCategoryPolicy(
+    val tier: Int,
+    val maxItems: Int,
+    val required: Boolean,
+    val contentLimitChars: Int?,
+    val fieldLimitChars: Int?,
+    val sourceType: String?,
+    val emptyLedgerText: String?,
+)
+
+internal data class MobileContextPolicy(
+    val schemaVersion: Int,
+    val policyVersion: Int,
+    val indexVersion: Int,
+    val sourceHash: String,
+    val requiredCategories: Set<String>,
+    val optionalCategories: Set<String>,
+    val contextWindowTokens: Int,
+    val safetyMarginTokens: Int,
+    val minimumOutputReserveTokens: Int,
+    val outputRatio: Double,
+    val categories: Map<String, MobileContextCategoryPolicy>,
+    val lexicalWeight: Double,
+    val recencyWeight: Double,
+    val structuralWeight: Double,
+) {
+    companion object {
+        fun fromJson(root: JsonObject): MobileContextPolicy {
+            val contract = root.objectValue("contract")
+            val defaults = root.objectValue("model_defaults")
+            val categoryRoot = root.objectValue("categories")
+            val fallback = root.objectValue("ranking").objectValue("lexical_fallback")
+            return MobileContextPolicy(
+                schemaVersion = root.intValue("schema_version", 1),
+                policyVersion = root.intValue("policy_version", 1),
+                indexVersion = root.intValue("index_version", 1),
+                sourceHash = root.stringValue("source_sha256"),
+                requiredCategories = contract.stringList("required_categories").toSet(),
+                optionalCategories = contract.stringList("optional_categories").toSet(),
+                contextWindowTokens = defaults.intValue("context_window_tokens", 16_384),
+                safetyMarginTokens = defaults.intValue("safety_margin_tokens", 512),
+                minimumOutputReserveTokens = defaults.intValue("minimum_output_reserve_tokens", 2_048),
+                outputRatio = defaults.doubleValue("output_ratio", 0.45),
+                categories = categoryRoot.mapValues { (_, raw) ->
+                    val value = raw as? JsonObject ?: JsonObject(emptyMap())
+                    MobileContextCategoryPolicy(
+                        tier = value.intValue("tier", 4),
+                        maxItems = value.intValue("max_items", 1),
+                        required = value.booleanValue("required"),
+                        contentLimitChars = value.optionalInt("content_limit_chars"),
+                        fieldLimitChars = value.optionalInt("field_limit_chars"),
+                        sourceType = value.stringValue("source_type").ifBlank { null },
+                        emptyLedgerText = value.stringValue("empty_ledger_text").ifBlank { null },
+                    )
+                },
+                lexicalWeight = fallback.doubleValue("lexical", 0.70),
+                recencyWeight = fallback.doubleValue("recency", 0.20),
+                structuralWeight = fallback.doubleValue("structural", 0.10),
+            )
+        }
+    }
+}
+
+internal class PcContextManifestPolicy(context: Context) {
+    private val json = Json { ignoreUnknownKeys = true }
+    val policy: MobileContextPolicy = context.assets.open(ASSET_NAME).bufferedReader(Charsets.UTF_8).use { reader ->
+        MobileContextPolicy.fromJson(json.parseToJsonElement(reader.readText()) as JsonObject)
+    }
+
+    companion object {
+        private const val ASSET_NAME = "pc_context_manifest_policy.json"
+    }
+}
+
+internal data class MobileContextRequest(
+    val outlineNodeId: String,
+    val targetChapterId: String,
+    val requirements: String,
+    val involvedCharacters: List<String>,
+    val characterLimit: Int,
+    val recentLimit: Int,
+) {
+    fun fingerprint(projectId: String): String = mobileSha256(
+        listOf(
+            "project=$projectId",
+            "outline=$outlineNodeId",
+            "chapter=$targetChapterId",
+            "requirements=$requirements",
+            "characters=${involvedCharacters.joinToString("\u001e")}",
+            "character_limit=$characterLimit",
+            "recent_limit=$recentLimit",
+        ).joinToString("\u001f"),
+    )
+
+    companion object {
+        fun fromArgs(args: JsonObject, policy: MobileContextPolicy): MobileContextRequest {
+            val maxCharacters = policy.categories["scene_character"]?.maxItems ?: 12
+            val maxSummaries = policy.categories["previous_summary"]?.maxItems ?: 3
+            return MobileContextRequest(
+                outlineNodeId = args.stringValue("outline_node_id")
+                    .ifBlank { args.stringValue("target_outline_node_id") },
+                targetChapterId = args.stringValue("chapter_id")
+                    .ifBlank { args.stringValue("target_chapter_id") },
+                requirements = args.stringValue("requirements")
+                    .ifBlank { args.stringValue("instruction") }
+                    .ifBlank { args.stringValue("request") }
+                    .trim(),
+                involvedCharacters = args.stringList("involved_characters")
+                    .ifEmpty { args.stringList("character_names") }
+                    .map(String::trim)
+                    .filter(String::isNotBlank)
+                    .distinct()
+                    .take(maxCharacters),
+                characterLimit = args.intValue("character_limit", min(8, maxCharacters))
+                    .coerceIn(1, maxCharacters),
+                recentLimit = args.intValue("recent_limit", maxSummaries)
+                    .coerceIn(1, maxSummaries),
+            )
+        }
+    }
+}
+
+internal data class MobileContextInputs(
+    val projectId: String,
+    val model: String,
+    val request: MobileContextRequest,
+    val project: JsonObject,
+    val styleText: String,
+    val primaryRecords: List<JsonObject>,
+    val rawRecords: List<JsonObject>,
+    val orderedChapters: List<JsonObject>,
+    val contextWindowTokens: Int? = null,
+    val maxOutputTokens: Int? = null,
+)
+
+internal data class MobileContextCoverage(
+    val required: Boolean,
+    val status: String,
+    val itemCount: Int,
+    val reason: String = "",
+) {
+    fun toJson(): JsonObject = buildJsonObject {
+        put("required", required)
+        put("status", status)
+        put("item_count", itemCount)
+        if (reason.isNotBlank()) put("reason", reason)
+    }
+}
+
+internal data class MobileContextManifestItem(
+    val category: String,
+    val sourceType: String,
+    val sourceId: String?,
+    val chunkId: String?,
+    val title: String,
+    val content: String,
+    val required: Boolean,
+    val tier: Int,
+    val lexicalScore: Double?,
+    val recencyScore: Double?,
+    val structuralScore: Double?,
+    val finalScore: Double,
+    val selectionReason: String,
+    val sourceHash: String = mobileSha256(content),
+) {
+    val estimatedTokens: Int get() = estimateMobileTokens(content)
+
+    fun identity(): String = listOf(sourceType, sourceId.orEmpty(), chunkId.orEmpty()).joinToString("\u001f")
+
+    fun toJson(includeContent: Boolean): JsonObject = buildJsonObject {
+        put("category", category)
+        put("source_type", sourceType)
+        sourceId?.let { put("source_id", it) }
+        chunkId?.let { put("chunk_id", it) }
+        put("source_hash", sourceHash)
+        put("title", title)
+        put("required", required)
+        put("pinned", false)
+        put("tier", tier)
+        put("scores", buildJsonObject {
+            lexicalScore?.let { put("lexical", it) }
+            recencyScore?.let { put("recency", it) }
+            structuralScore?.let { put("structural", it) }
+            put("final", finalScore)
+        })
+        put("selection_reason", selectionReason)
+        put("estimated_tokens", estimatedTokens)
+        if (includeContent) put("content", content)
+    }
+}
+
+internal data class MobileContextManifest(
+    val id: String,
+    val projectId: String,
+    val model: String,
+    val policyVersion: Int,
+    val indexVersion: Int,
+    val policySourceHash: String,
+    val status: String,
+    val request: MobileContextRequest,
+    val requestFingerprint: String,
+    val selectionFingerprint: String,
+    val contextWindowTokens: Int,
+    val inputBudgetTokens: Int,
+    val outputReserveTokens: Int,
+    val safetyMarginTokens: Int,
+    val items: List<MobileContextManifestItem>,
+    val coverage: Map<String, MobileContextCoverage>,
+    val warnings: List<String>,
+) {
+    val estimatedInputTokens: Int get() = items.sumOf(MobileContextManifestItem::estimatedTokens)
+    val estimatedInputChars: Int get() = items.sumOf { it.content.length }
+
+    fun items(category: String): List<MobileContextManifestItem> = items.filter { it.category == category }
+
+    fun renderedContext(): String {
+        val grouped = linkedMapOf<String, MutableList<MobileContextManifestItem>>()
+        items.forEach { item -> grouped.getOrPut(item.category) { mutableListOf() } += item }
+        return buildList {
+            add("# Governed Task Context")
+            grouped.forEach { (category, values) ->
+                add("\n## $category")
+                values.forEach { add("### ${it.title}\n${it.content}") }
+            }
+        }.joinToString("\n\n").trim()
+    }
+
+    fun toJson(includeContent: Boolean = false): JsonObject = buildJsonObject {
+        put("id", id)
+        put("project_id", projectId)
+        put("task_type", "writing")
+        put("model", model)
+        put("execution_route", "android_standalone")
+        put("policy_version", policyVersion)
+        put("index_version", indexVersion)
+        put("policy_source_sha256", policySourceHash)
+        put("status", status)
+        put("request_fingerprint", requestFingerprint)
+        put("selection_fingerprint", selectionFingerprint)
+        put("budget", buildJsonObject {
+            put("context_window_tokens", contextWindowTokens)
+            put("input_budget_tokens", inputBudgetTokens)
+            put("output_reserve_tokens", outputReserveTokens)
+            put("safety_margin_tokens", safetyMarginTokens)
+            put("estimated_input_tokens", estimatedInputTokens)
+            put("estimated_input_chars", estimatedInputChars)
+            put("remaining_input_tokens", max(0, inputBudgetTokens - estimatedInputTokens))
+        })
+        put("coverage", buildJsonObject {
+            coverage.forEach { (category, value) -> put(category, value.toJson()) }
+        })
+        put("warnings", JsonArray(warnings.map(::JsonPrimitive)))
+        put("items", JsonArray(items.map { it.toJson(includeContent) }))
+        if (includeContent) put("rendered_context", renderedContext())
+    }
+}
+
+internal data class MobileContextValidation(
+    val status: String,
+    val detail: String,
+    val current: MobileContextManifest,
+) {
+    val ready: Boolean get() = status == "ready"
+}
+
+/** Deterministic Android projection of the PC writing ContextManifest policy. */
+internal class MobileContextManifestEngine(
+    private val policy: MobileContextPolicy,
+) {
+    fun prepare(inputs: MobileContextInputs, id: String = UUID.randomUUID().toString()): MobileContextManifest {
+        val requestFingerprint = inputs.request.fingerprint(inputs.projectId)
+        val coverage = linkedMapOf<String, MobileContextCoverage>()
+        val candidates = mutableListOf<MobileContextManifestItem>()
+        val warnings = mutableListOf<String>()
+
+        addStyle(inputs, candidates, coverage)
+        addTargetOutline(inputs, candidates, coverage)
+        addRequirements(inputs, candidates, coverage)
+        addPreviousSummaries(inputs, candidates, coverage)
+        val resolution = addSceneCharacters(inputs, candidates, coverage)
+        addGovernance(inputs, candidates, coverage)
+        addWorldRetrieval(inputs, candidates, coverage)
+
+        val requestedNames = inputs.request.involvedCharacters.toSet()
+        val matchedNames = resolution.characters.mapTo(mutableSetOf()) { it.stringValue("name") } +
+            resolution.resolvedAliases.keys
+        val missingNames = requestedNames - matchedNames
+        if (missingNames.isNotEmpty()) {
+            warnings += "部分指定角色未命中角色卡或别名：${missingNames.joinToString("、")}"
+        }
+
+        val window = max(1, inputs.contextWindowTokens ?: policy.contextWindowTokens)
+        val ratioLimit = (window * policy.outputRatio).toInt()
+        val configuredLimit = inputs.maxOutputTokens ?: ratioLimit
+        val outputReserve = max(policy.minimumOutputReserveTokens, min(configuredLimit, ratioLimit))
+        val inputBudget = max(0, window - outputReserve - policy.safetyMarginTokens)
+        val selected = budget(candidates, coverage, warnings, inputBudget)
+        val missingRequired = policy.requiredCategories.filter { category ->
+            coverage[category]?.status !in setOf("covered", "not_applicable")
+        }
+        val status = if (missingRequired.isEmpty()) "ready" else "needs_confirmation"
+        if (missingRequired.isNotEmpty()) {
+            warnings += "Required context is missing: ${missingRequired.joinToString(", ")}"
+        }
+        warnings += "手机独立模式使用保守 16K 上下文与本地词法检索；未启用 PC FTS、向量检索或 pinned chunks。"
+
+        val selectionFingerprint = mobileSha256(
+            selected.joinToString("\u001e") { item ->
+                listOf(item.category, item.sourceType, item.sourceId.orEmpty(), item.chunkId.orEmpty(), item.sourceHash)
+                    .joinToString("\u001f")
+            },
+        )
+        return MobileContextManifest(
+            id = id,
+            projectId = inputs.projectId,
+            model = inputs.model,
+            policyVersion = policy.policyVersion,
+            indexVersion = policy.indexVersion,
+            policySourceHash = policy.sourceHash,
+            status = status,
+            request = inputs.request,
+            requestFingerprint = requestFingerprint,
+            selectionFingerprint = selectionFingerprint,
+            contextWindowTokens = window,
+            inputBudgetTokens = inputBudget,
+            outputReserveTokens = outputReserve,
+            safetyMarginTokens = policy.safetyMarginTokens,
+            items = selected,
+            coverage = coverage.toMap(),
+            warnings = warnings.distinct(),
+        )
+    }
+
+    fun validate(existing: MobileContextManifest, inputs: MobileContextInputs): MobileContextValidation {
+        val current = prepare(inputs, id = existing.id)
+        val staleReason = when {
+            existing.policyVersion != policy.policyVersion ||
+                existing.indexVersion != policy.indexVersion ||
+                existing.policySourceHash != policy.sourceHash -> "PC 上下文策略版本已变化，请重新预检。"
+            existing.model != inputs.model -> "模型已从 ${existing.model} 切换为 ${inputs.model}，请重新预检。"
+            existing.requestFingerprint != current.requestFingerprint -> "写作目标、要求或角色选择已变化，请重新预检。"
+            existing.selectionFingerprint != current.selectionFingerprint -> "已选择的上下文来源发生变化，请重新预检。"
+            current.status != "ready" -> "当前必选上下文不完整，需要作者确认。"
+            else -> ""
+        }
+        return if (staleReason.isBlank()) {
+            MobileContextValidation("ready", "ContextManifest 仍然有效。", current)
+        } else if (current.status == "needs_confirmation" && existing.requestFingerprint == current.requestFingerprint) {
+            MobileContextValidation("needs_confirmation", staleReason, current.copy(status = "needs_confirmation"))
+        } else {
+            MobileContextValidation("stale", staleReason, current.copy(status = "stale"))
+        }
+    }
+
+    private fun addStyle(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ) {
+        val content = inputs.styleText.trim()
+        if (content.isBlank()) {
+            coverage["style"] = MobileContextCoverage(true, "missing", 0, "Project style is required.")
+            return
+        }
+        candidates += item(
+            category = "style",
+            sourceType = "project_style",
+            sourceId = inputs.projectId,
+            title = "Project style and fixed constraints",
+            content = content,
+            required = true,
+            score = 1.0,
+            reason = "Required project-level style and author constraints.",
+        )
+        coverage["style"] = MobileContextCoverage(true, "covered", 1)
+    }
+
+    private fun addTargetOutline(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ) {
+        val target = inputs.request.outlineNodeId.takeIf(String::isNotBlank)?.let { id ->
+            inputs.rawRecords.firstOrNull { it.mobileRecordType() == "outline_node" && it.stringValue("id") == id }
+                ?: inputs.primaryRecords.firstOrNull {
+                    it.mobileRecordType() == "outline_node" && it.stringValue("id") == id
+                }
+        }
+        if (target == null) {
+            val reason = if (inputs.request.outlineNodeId.isBlank()) {
+                "Writing needs a target outline or section."
+            } else {
+                "The selected outline node no longer exists."
+            }
+            coverage["target_outline"] = MobileContextCoverage(true, "missing", 0, reason)
+            return
+        }
+        candidates += item(
+            category = "target_outline",
+            sourceType = "outline",
+            sourceId = target.stringValue("id"),
+            title = target.stringValue("title").ifBlank { "Target outline" },
+            content = mobileOutlineText(target, policy.categories["target_outline"]?.fieldLimitChars ?: 1_200),
+            required = true,
+            score = 1.0,
+            reason = "Target outline/section required by the writing contract.",
+            sourceHash = mobileSha256(canonicalMobileJson(target)),
+        )
+        coverage["target_outline"] = MobileContextCoverage(true, "covered", 1)
+    }
+
+    private fun addRequirements(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ) {
+        val text = inputs.request.requirements.trim()
+        if (text.isBlank()) {
+            coverage["user_requirement"] = MobileContextCoverage(false, "not_applicable", 0)
+            return
+        }
+        val limit = policy.categories["user_requirement"]?.contentLimitChars ?: 4_000
+        candidates += item(
+            category = "user_requirement",
+            sourceType = "inline",
+            sourceId = "user-requirement",
+            title = "Author request",
+            content = cleanMobileText(text, limit),
+            required = false,
+            score = 0.95,
+            reason = "Explicit request passed to this task.",
+        )
+        coverage["user_requirement"] = MobileContextCoverage(false, "covered", 1)
+    }
+
+    private fun addPreviousSummaries(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ) {
+        val limit = policy.categories["previous_summary"]?.contentLimitChars ?: 1_600
+        val rows = inputs.orderedChapters
+            .filter { inputs.request.targetChapterId.isBlank() || it.stringValue("id") != inputs.request.targetChapterId }
+            .filter { it.stringValue("summary").isNotBlank() }
+            .takeLast(inputs.request.recentLimit)
+        rows.forEachIndexed { index, chapter ->
+            val score = max(0.2, 0.9 - (rows.lastIndex - index) * 0.1)
+            candidates += item(
+                category = "previous_summary",
+                sourceType = "chapter_summary",
+                sourceId = chapter.stringValue("id"),
+                title = "Previous summary: ${chapter.stringValue("title")}",
+                content = cleanMobileText(chapter.stringValue("summary"), limit),
+                required = false,
+                score = score,
+                recency = max(0.2, 1.0 - (rows.lastIndex - index) * 0.15),
+                structural = 0.8,
+                reason = "Most recent confirmed chapter summary.",
+                sourceHash = mobileSha256(chapter.stringValue("summary")),
+            )
+        }
+        coverage["previous_summary"] = MobileContextCoverage(
+            required = false,
+            status = if (rows.isEmpty()) "not_applicable" else "covered",
+            itemCount = rows.size,
+        )
+    }
+
+    private fun addSceneCharacters(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ): PcCharacterResolution {
+        val resolution = resolvePcCharacters(
+            inputs.rawRecords,
+            inputs.request.outlineNodeId.takeIf(String::isNotBlank),
+            inputs.request.involvedCharacters,
+            inputs.request.characterLimit,
+        )
+        val limit = policy.categories["scene_character"]?.contentLimitChars ?: 12_000
+        resolution.characters.forEach { character ->
+            candidates += item(
+                category = "scene_character",
+                sourceType = "character",
+                sourceId = character.stringValue("id"),
+                title = character.stringValue("name").ifBlank { "Character" },
+                content = cleanMobileText(pcCharacterDetails(inputs.rawRecords, listOf(character)), limit),
+                required = false,
+                score = 0.95,
+                structural = 0.95,
+                reason = "Character explicitly selected or linked to the target outline.",
+                sourceHash = mobileSha256(
+                    buildString {
+                        append(canonicalMobileJson(character))
+                        inputs.rawRecords.asSequence()
+                            .filter { it.mobileRecordType() == "character_relationship" }
+                            .filter {
+                                it.stringValue("from") == character.stringValue("id") ||
+                                    it.stringValue("to") == character.stringValue("id")
+                            }
+                            .sortedBy { it.stringValue("id") }
+                            .forEach { append("\u001e").append(canonicalMobileJson(it)) }
+                    },
+                ),
+            )
+        }
+        val characterCount = inputs.rawRecords.count { it.mobileRecordType() == "character" }
+        coverage["scene_character"] = MobileContextCoverage(
+            required = false,
+            status = when {
+                resolution.characters.isNotEmpty() -> "covered"
+                characterCount == 0 -> "not_applicable"
+                else -> "missing"
+            },
+            itemCount = resolution.characters.size,
+            reason = if (characterCount > 0 && resolution.characters.isEmpty()) "No target character was resolved." else "",
+        )
+        return resolution
+    }
+
+    private fun addGovernance(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ) {
+        val category = policy.categories["narrative_governance"]
+        val content = pcGovernanceContext(inputs.rawRecords)
+            .ifBlank { category?.emptyLedgerText ?: "Narrative governance: no due or high-risk items." }
+        candidates += item(
+            category = "narrative_governance",
+            sourceType = "narrative_governance",
+            sourceId = inputs.request.targetChapterId.ifBlank { inputs.projectId },
+            title = "Narrative governance ledger",
+            content = cleanMobileText(content, category?.contentLimitChars ?: 5_000),
+            required = false,
+            score = 0.85,
+            structural = 0.85,
+            reason = "Current debts, foreshadowing, causal chains and state conflicts.",
+        )
+        coverage["narrative_governance"] = MobileContextCoverage(false, "covered", 1)
+    }
+
+    private fun addWorldRetrieval(
+        inputs: MobileContextInputs,
+        candidates: MutableList<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+    ) {
+        val outline = candidates.firstOrNull { it.category == "target_outline" }
+        val query = listOf(inputs.request.requirements, outline?.title.orEmpty(), outline?.content.orEmpty())
+            .filter(String::isNotBlank)
+            .joinToString("\n")
+            .take(12_000)
+        val queryTokens = lexicalTokens(query)
+        val rows = inputs.rawRecords
+            .filter { it.mobileRecordType() == "world_entry" }
+            .distinctBy { it.stringValue("id") }
+            .sortedWith(
+                compareByDescending<JsonObject> { it.stringValue("updated_at") }
+                    .thenByDescending { it.stringValue("created_at") }
+                    .thenBy { it.stringValue("title") },
+            )
+        if (queryTokens.isEmpty() || rows.isEmpty()) {
+            coverage["hybrid_retrieval"] = MobileContextCoverage(false, "not_applicable", 0)
+            return
+        }
+        val rawScores = rows.map { world ->
+            val text = listOf(
+                world.stringValue("dimension"),
+                world.stringValue("title"),
+                world.stringValue("content"),
+                world.stringValue("constraints"),
+                world.stringValue("plot_usage"),
+            ).joinToString("\n")
+            world to lexicalOverlap(queryTokens, lexicalTokens(text))
+        }
+        val maxLexical = rawScores.maxOfOrNull { it.second } ?: 0.0
+        val category = policy.categories["hybrid_retrieval"]
+        val ranked = rawScores.mapIndexedNotNull { index, (world, rawLexical) ->
+            if (rawLexical <= 0.0 || maxLexical <= 0.0) return@mapIndexedNotNull null
+            val lexical = rawLexical / maxLexical
+            val recency = max(0.05, 1.0 / (1.0 + index.toDouble() / 8.0))
+            val structural = 0.25
+            val final = lexical * policy.lexicalWeight +
+                recency * policy.recencyWeight +
+                structural * policy.structuralWeight
+            item(
+                category = "hybrid_retrieval",
+                sourceType = "worldbuilding",
+                sourceId = world.stringValue("id"),
+                title = world.stringValue("title").ifBlank { world.stringValue("dimension").ifBlank { "Worldbuilding" } },
+                content = cleanMobileText(
+                    "【${world.stringValue("dimension").ifBlank { "culture" }}·${world.stringValue("title")}】\n" +
+                        world.stringValue("content"),
+                    category?.contentLimitChars ?: 1_800,
+                ),
+                required = false,
+                score = final,
+                lexical = lexical,
+                recency = recency,
+                structural = structural,
+                reason = "Lexical fallback ranking: lexical 70%, recency 20%, structure 10%.",
+                sourceHash = mobileSha256(canonicalMobileJson(world)),
+            )
+        }.sortedWith(compareByDescending<MobileContextManifestItem> { it.finalScore }.thenBy { it.title })
+            .take(category?.maxItems ?: 24)
+        candidates += ranked
+        coverage["hybrid_retrieval"] = MobileContextCoverage(
+            required = false,
+            status = if (ranked.isEmpty()) "not_applicable" else "covered",
+            itemCount = ranked.size,
+        )
+    }
+
+    private fun budget(
+        candidates: List<MobileContextManifestItem>,
+        coverage: MutableMap<String, MobileContextCoverage>,
+        warnings: MutableList<String>,
+        inputBudget: Int,
+    ): List<MobileContextManifestItem> {
+        val selected = mutableListOf<MobileContextManifestItem>()
+        val seen = mutableSetOf<String>()
+        var used = 0
+        candidates.sortedWith(
+            compareBy<MobileContextManifestItem> { it.tier }
+                .thenBy { if (it.required) 0 else 1 }
+                .thenByDescending { it.finalScore }
+                .thenBy { it.title },
+        ).forEach { candidate ->
+            if (candidate.identity() in seen) return@forEach
+            if (used + candidate.estimatedTokens <= inputBudget) {
+                selected += candidate
+                used += candidate.estimatedTokens
+                seen += candidate.identity()
+            } else if (candidate.required) {
+                coverage[candidate.category] = MobileContextCoverage(
+                    required = true,
+                    status = "missing",
+                    itemCount = 0,
+                    reason = "Required anchor exceeds the remaining context budget.",
+                )
+                warnings += "Required context '${candidate.title}' did not fit the input budget."
+            } else if (candidate.category == "hybrid_retrieval" && candidate.finalScore >= 0.6) {
+                warnings += "Relevant retrieved source '${candidate.title}' was omitted by the budget."
+            }
+        }
+        val counts = selected.groupingBy(MobileContextManifestItem::category).eachCount()
+        coverage.keys.toList().forEach { category ->
+            val current = coverage.getValue(category)
+            if (current.status == "covered") {
+                val count = counts[category] ?: 0
+                if (count == 0) {
+                    coverage[category] = current.copy(
+                        status = if (current.required) "missing" else "not_selected",
+                        itemCount = 0,
+                    )
+                } else {
+                    coverage[category] = current.copy(itemCount = count)
+                }
+            }
+        }
+        return selected
+    }
+
+    private fun item(
+        category: String,
+        sourceType: String,
+        sourceId: String?,
+        title: String,
+        content: String,
+        required: Boolean,
+        score: Double,
+        reason: String,
+        lexical: Double? = null,
+        recency: Double? = null,
+        structural: Double? = null,
+        sourceHash: String? = null,
+    ): MobileContextManifestItem = MobileContextManifestItem(
+        category = category,
+        sourceType = sourceType,
+        sourceId = sourceId,
+        chunkId = null,
+        title = title,
+        content = content,
+        required = required,
+        tier = policy.categories[category]?.tier ?: 4,
+        lexicalScore = lexical,
+        recencyScore = recency,
+        structuralScore = structural,
+        finalScore = score,
+        selectionReason = reason,
+        sourceHash = sourceHash ?: mobileSha256(content),
+    )
+}
+
+internal fun estimateMobileTokens(text: String): Int {
+    if (text.isEmpty()) return 0
+    val cjk = text.count { character -> character in '\u4e00'..'\u9fff' || character in '\u3400'..'\u4dbf' }
+    val nonCjk = text.length - cjk
+    return cjk + max(1, nonCjk / 4)
+}
+
+internal fun mobileSha256(value: String): String = MessageDigest.getInstance("SHA-256")
+    .digest(value.toByteArray(Charsets.UTF_8))
+    .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+
+private fun mobileOutlineText(node: JsonObject, fieldLimit: Int): String = buildList {
+    add("Outline: ${node.stringValue("title")}")
+    add("Node type: ${node.stringValue("node_type").ifBlank { "unknown" }}")
+    listOf(
+        "Summary" to node.stringValue("summary"),
+        "Planned" to node.stringValue("planned_summary"),
+        "Actual" to node.stringValue("actual_summary"),
+        "Status" to node.stringValue("status"),
+    ).forEach { (label, value) -> if (value.isNotBlank()) add("$label: ${cleanMobileText(value, fieldLimit)}") }
+}.joinToString("\n")
+
+private fun cleanMobileText(value: String, limit: Int): String {
+    val text = value.trim()
+    if (text.length <= limit) return text
+    if (limit <= 3) return text.take(limit)
+    return text.take(limit - 3).trimEnd() + "..."
+}
+
+private fun lexicalTokens(text: String): Set<String> {
+    if (text.isBlank()) return emptySet()
+    val tokens = linkedSetOf<String>()
+    val latin = StringBuilder()
+    fun flushLatin() {
+        if (latin.isNotEmpty()) {
+            tokens += latin.toString().lowercase()
+            latin.clear()
+        }
+    }
+    val cjkRun = StringBuilder()
+    fun flushCjk() {
+        if (cjkRun.isEmpty()) return
+        for (index in cjkRun.indices) {
+            tokens += cjkRun[index].toString()
+            if (index + 1 < cjkRun.length) tokens += cjkRun.substring(index, index + 2)
+        }
+        cjkRun.clear()
+    }
+    text.forEach { character ->
+        when {
+            character in '\u4e00'..'\u9fff' || character in '\u3400'..'\u4dbf' -> {
+                flushLatin()
+                cjkRun.append(character)
+            }
+            character.isLetterOrDigit() -> {
+                flushCjk()
+                latin.append(character.lowercaseChar())
+            }
+            else -> {
+                flushLatin()
+                flushCjk()
+            }
+        }
+    }
+    flushLatin()
+    flushCjk()
+    return tokens
+}
+
+private fun lexicalOverlap(query: Set<String>, source: Set<String>): Double {
+    if (query.isEmpty() || source.isEmpty()) return 0.0
+    return query.count { it in source }.toDouble() / query.size.toDouble()
+}
+
+private fun canonicalMobileJson(element: JsonElement): String = when (element) {
+    is JsonObject -> element.entries.sortedBy { it.key }
+        .joinToString(prefix = "{", postfix = "}", separator = ",") { (key, value) ->
+            JsonPrimitive(key).toString() + ":" + canonicalMobileJson(value)
+        }
+    is JsonArray -> element.joinToString(prefix = "[", postfix = "]", separator = ",", transform = ::canonicalMobileJson)
+    else -> element.toString()
+}
+
+private fun JsonObject.mobileRecordType(): String = stringValue("_record_type")
+
+private fun JsonObject.objectValue(name: String): JsonObject = get(name) as? JsonObject ?: JsonObject(emptyMap())
+
+private fun JsonObject.stringValue(name: String): String = (get(name) as? JsonPrimitive)?.contentOrNull.orEmpty()
+
+private fun JsonObject.intValue(name: String, fallback: Int): Int = (get(name) as? JsonPrimitive)?.intOrNull ?: fallback
+
+private fun JsonObject.optionalInt(name: String): Int? = (get(name) as? JsonPrimitive)?.intOrNull
+
+private fun JsonObject.doubleValue(name: String, fallback: Double): Double =
+    (get(name) as? JsonPrimitive)?.doubleOrNull ?: fallback
+
+private fun JsonObject.booleanValue(name: String): Boolean = (get(name) as? JsonPrimitive)?.booleanOrNull ?: false
+
+private fun JsonObject.stringList(name: String): List<String> = when (val value = get(name)) {
+    is JsonArray -> value.mapNotNull { (it as? JsonPrimitive)?.contentOrNull?.trim() }.filter(String::isNotBlank)
+    is JsonPrimitive -> value.contentOrNull.orEmpty().split(',', '，').map(String::trim).filter(String::isNotBlank)
+    else -> emptyList()
+}

--- a/mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt
+++ b/mobile/android/app/src/main/java/com/siming/mobile/data/agent/MobileWorkspaceAgent.kt
@@ -36,8 +36,11 @@ internal class MobileWorkspaceAgent(
     private val saveEntity: suspend (String, String, String, JsonObject) -> String,
 ) {
     private val contract = PcPromptContract(context.applicationContext)
+    private val contextPolicy = PcContextManifestPolicy(context.applicationContext).policy
+    private val contextEngine = MobileContextManifestEngine(contextPolicy)
     private val json = Json { ignoreUnknownKeys = true }
     private val chapterDrafts = LinkedHashMap<String, String>()
+    private val contextManifests = LinkedHashMap<String, MobileContextManifest>()
 
     suspend fun run(
         projectId: String,
@@ -123,7 +126,7 @@ internal class MobileWorkspaceAgent(
         "search_outline" -> searchOutline(projectId, args)
         "search_outline_tree" -> searchOutlineTree(projectId, args)
         "search_worldbuilding" -> searchWorldbuilding(projectId, args)
-        "preview_writing_context" -> previewWritingContext(projectId, args)
+        "preview_writing_context" -> previewWritingContext(projectId, args, config)
         "chapter_writer" -> chapterWriter(projectId, args, config)
         "character_writer" -> characterWriter(projectId, args, config)
         "outline_writer" -> outlineWriter(projectId, args, config)
@@ -302,64 +305,63 @@ internal class MobileWorkspaceAgent(
         )
     }
 
-    private suspend fun previewWritingContext(projectId: String, args: JsonObject): JsonObject {
+    private suspend fun previewWritingContext(
+        projectId: String,
+        args: JsonObject,
+        config: DirectApiConfig,
+    ): JsonObject {
         val all = records(projectId)
         val rawPayloads = rawRecords(projectId).map(LocalRecord::payload)
-        val outlineId = args.string("outline_node_id")
-        val involved = args.stringList("involved_characters").take(12)
-        val characterLimit = args.int("character_limit", 8).coerceIn(1, 16)
-        val recentLimit = args.int("recent_limit", 5).coerceIn(1, 12)
-        val chapters = orderedChapters(all)
+        val project = all.firstOrNull { it.entity.entityType == "project" }?.payload
+            ?: return skipped("preview_writing_context", "项目不存在", JsonObject(emptyMap()))
+        val request = MobileContextRequest.fromArgs(args, contextPolicy)
+        val inputs = manifestInputs(projectId, config, request, project, all, rawPayloads)
+        val manifest = contextEngine.prepare(inputs)
+        cacheManifest(manifestKey(projectId, request), manifest)
+
         val resolved = resolvePcCharacters(
             rawPayloads,
-            outlineId.takeIf(String::isNotBlank),
-            involved,
-            characterLimit,
+            request.outlineNodeId.takeIf(String::isNotBlank),
+            request.involvedCharacters,
+            request.characterLimit,
         )
         val characters = resolved.characters.map(::clean)
         val relationships = pcRelationshipPayloads(rawPayloads, resolved.characters)
-        val governance = pcGovernanceContext(rawPayloads)
-        val recent = chapters.takeLast(recentLimit)
+        val recent = orderedChapters(all).takeLast(request.recentLimit)
             .map { select(it.payload, "id", "title", "outline_node_id", "word_count", "summary") }
-        val outline = outlineContext(all, outlineId)
-        val world = worldContext(all)
-        val matchedNames = resolved.characters.mapTo(mutableSetOf()) { it.string("name") } +
-            resolved.resolvedAliases.keys
-        val missingNames = involved.filterNot { it in matchedNames }
-        val warnings = buildJsonArray {
-            if (outlineId.isNotBlank() && all.none { it.entity.entityType == "outline" && it.entity.entityId == outlineId }) {
-                add(JsonPrimitive("未找到目标大纲节点，章节写作可能会偏离规划。"))
-            }
-            if (missingNames.isNotEmpty()) {
-                add(JsonPrimitive("部分指定角色未命中角色卡或别名：${missingNames.joinToString("、")}"))
-            }
-            if (characters.isEmpty()) add(JsonPrimitive("本次写作未命中任何角色当前状态。"))
-            if (world == "暂无世界观设定。") add(JsonPrimitive("本次写作没有可用世界观设定。"))
-        }
-        val usedChars = outline.length + world.length + governance.length
+        val outline = manifest.categoryText("target_outline", "暂无当前大纲节点。")
+        val worldItems = manifest.items.filter { it.sourceType == "worldbuilding" }
+        val world = worldItems.joinToString("\n\n") { it.content }.ifBlank { "暂无世界观设定。" }
+        val governance = manifest.categoryText(
+            "narrative_governance",
+            "Narrative governance: no due or high-risk items.",
+        )
+        val summaries = manifest.categoryText("previous_summary", "暂无前文摘要。")
         val data = buildJsonObject {
             put("outline_context", outline)
             put("recent_chapters", JsonArray(recent))
-            put("recent_summaries_text", recentSummaries(all, recentLimit))
+            put("recent_summaries_text", summaries)
             put("characters", JsonArray(characters))
             put("relationships", relationships)
             put("world_context", world)
             put("narrative_governance_context", governance)
-            put("warnings", warnings)
-            put("requirements_preview", args.string("requirements").take(1_000))
+            put("warnings", JsonArray(manifest.warnings.map(::JsonPrimitive)))
+            put("requirements_preview", request.requirements.take(1_000))
             put("resolved_aliases", jsonStringMap(resolved.resolvedAliases))
-            put("rag_sections", JsonArray(emptyList()))
-            put("total_used_chars", usedChars)
-            put("total_estimated_tokens", usedChars.coerceAtLeast(1) / 4)
-            put("rag_used", false)
+            put("rag_sections", JsonArray(worldItems.map { it.toJson(includeContent = false) }))
+            put("total_used_chars", manifest.estimatedInputChars)
+            put("total_estimated_tokens", manifest.estimatedInputTokens)
+            put("rag_used", worldItems.isNotEmpty())
             put("fts_available", false)
             put("auto_indexed", false)
+            put("context_manifest", manifest.toJson(includeContent = false))
         }
-        return ok(
-            "preview_writing_context",
-            "写作上下文预检：${characters.size} 个角色、${relationships.size} 条关系、${warnings.size} 条风险",
-            data,
-        )
+        val detail = if (manifest.status == "ready") {
+            "写作上下文预检通过：${characters.size} 个角色、${relationships.size} 条关系、${manifest.warnings.size} 条提示"
+        } else {
+            "写作上下文需要确认：必选大纲或文风锚点不完整"
+        }
+        return ok("preview_writing_context", detail, data)
     }
 
     private suspend fun chapterWriter(
@@ -371,26 +373,57 @@ internal class MobileWorkspaceAgent(
         val rawPayloads = rawRecords(projectId).map(LocalRecord::payload)
         val project = all.firstOrNull { it.entity.entityType == "project" }?.payload
             ?: return skipped("chapter_writer", "项目不存在", JsonObject(emptyMap()))
-        val outlineId = args.string("outline_node_id")
-        val involved = args.stringList("involved_characters").take(12)
-        val resolved = resolvePcCharacters(
-            rawPayloads,
-            outlineId.takeIf(String::isNotBlank),
-            involved,
-            12,
+        val request = MobileContextRequest.fromArgs(args, contextPolicy)
+        val inputs = manifestInputs(projectId, config, request, project, all, rawPayloads)
+        val key = manifestKey(projectId, request)
+        val cached = contextManifests[key]
+        val manifest = if (cached == null) {
+            contextEngine.prepare(inputs).also { cacheManifest(key, it) }
+        } else {
+            val validation = contextEngine.validate(cached, inputs)
+            if (!validation.ready) {
+                return skipped(
+                    "chapter_writer",
+                    validation.detail,
+                    buildJsonObject {
+                        put("context_status", validation.status)
+                        put("context_manifest", validation.current.toJson(includeContent = false))
+                        put("requires_preview", true)
+                    },
+                )
+            }
+            validation.current.also { cacheManifest(key, it) }
+        }
+        if (manifest.status != "ready") {
+            return skipped(
+                "chapter_writer",
+                "写作上下文缺少必选锚点，请先完成预检并确认目标大纲。",
+                buildJsonObject {
+                    put("context_status", manifest.status)
+                    put("context_manifest", manifest.toJson(includeContent = false))
+                    put("requires_preview", true)
+                },
+            )
+        }
+
+        val governance = manifest.categoryText(
+            "narrative_governance",
+            "Narrative governance: no due or high-risk items.",
         )
-        val governance = pcGovernanceContext(rawPayloads)
-        val worldAndGovernance = listOf(worldContext(all), governance)
+        val world = manifest.items.filter { it.sourceType == "worldbuilding" }
+            .joinToString("\n\n") { it.content }
+            .ifBlank { "暂无世界观设定。" }
+        val worldAndGovernance = listOf(world, governance)
             .filter(String::isNotBlank)
             .joinToString("\n\n")
-        val requirements = args.string("requirements")
+        val requirements = manifest.categoryText("user_requirement", request.requirements)
         val messages = contract.chapterMessages(
             mode = args.string("mode").ifBlank { "quality" },
             project = project,
-            outlineContext = outlineContext(all, outlineId),
+            outlineContext = manifest.categoryText("target_outline", "暂无当前大纲节点。"),
             worldContext = worldAndGovernance,
-            characterProfiles = pcCharacterDetails(rawPayloads, resolved.characters),
-            recentSummaries = recentSummaries(all, 5),
+            characterProfiles = manifest.categoryText("scene_character", "未指定角色。"),
+            recentSummaries = manifest.categoryText("previous_summary", "暂无前文摘要。"),
             requirements = requirements,
         )
         val content = directApi.complete(
@@ -404,8 +437,15 @@ internal class MobileWorkspaceAgent(
         val draftId = UUID.randomUUID().toString()
         chapterDrafts[draftId] = content
         while (chapterDrafts.size > MAX_DRAFTS) chapterDrafts.remove(chapterDrafts.keys.first())
-        val outlineTitle = all.firstOrNull { it.entity.entityType == "outline" && it.entity.entityId == outlineId }
-            ?.payload?.string("title").orEmpty()
+        val outlineTitle = all.firstOrNull {
+            it.entity.entityType == "outline" && it.entity.entityId == request.outlineNodeId
+        }?.payload?.string("title").orEmpty()
+        val resolved = resolvePcCharacters(
+            rawPayloads,
+            request.outlineNodeId.takeIf(String::isNotBlank),
+            request.involvedCharacters,
+            request.characterLimit,
+        )
         val data = buildJsonObject {
             put("draft_id", draftId)
             put("content_ref", draftId)
@@ -413,13 +453,21 @@ internal class MobileWorkspaceAgent(
             put("word_count", countWords(content))
             put("model", config.model)
             put("context_snapshot", buildJsonObject {
-                put("outline_node_id", outlineId)
+                put("outline_node_id", request.outlineNodeId)
                 put("outline_title", outlineTitle)
-                put("involved_characters", JsonArray(involved.map(::JsonPrimitive)))
+                put("involved_characters", JsonArray(request.involvedCharacters.map(::JsonPrimitive)))
                 put("resolved_aliases", jsonStringMap(resolved.resolvedAliases))
                 put("relationship_count", pcRelationshipPayloads(rawPayloads, resolved.characters).size)
                 put("narrative_governance_used", governance.isNotBlank())
                 put("prompt_contract_sha256", contract.sourceHash)
+                put("context_manifest_id", manifest.id)
+                put("context_policy_version", manifest.policyVersion)
+                put("context_index_version", manifest.indexVersion)
+                put("context_policy_sha256", manifest.policySourceHash)
+                put("context_request_fingerprint", manifest.requestFingerprint)
+                put("context_selection_fingerprint", manifest.selectionFingerprint)
+                put("context_status", manifest.status)
+                put("context_estimated_input_tokens", manifest.estimatedInputTokens)
                 put("execution_route", "android_standalone")
             })
         }
@@ -722,6 +770,37 @@ internal class MobileWorkspaceAgent(
         saveEntity(projectId, "world", current.entity.entityId, payload)
         return ok("update_worldbuilding_entry", "已更新世界观：${payload.string("title")}", clean(payload))
     }
+
+    private fun manifestInputs(
+        projectId: String,
+        config: DirectApiConfig,
+        request: MobileContextRequest,
+        project: JsonObject,
+        all: List<LocalRecord>,
+        rawPayloads: List<JsonObject>,
+    ): MobileContextInputs = MobileContextInputs(
+        projectId = projectId,
+        model = config.model,
+        request = request,
+        project = project,
+        styleText = contract.styleContext(project),
+        primaryRecords = all.map(LocalRecord::payload),
+        rawRecords = rawPayloads,
+        orderedChapters = orderedChapters(all).map(LocalRecord::payload),
+    )
+
+    private fun manifestKey(projectId: String, request: MobileContextRequest): String =
+        "$projectId|${request.outlineNodeId.ifBlank { request.targetChapterId.ifBlank { "unscoped" } }}"
+
+    private fun cacheManifest(key: String, manifest: MobileContextManifest) {
+        contextManifests[key] = manifest
+        while (contextManifests.size > MAX_CONTEXT_MANIFESTS) {
+            contextManifests.remove(contextManifests.keys.first())
+        }
+    }
+
+    private fun MobileContextManifest.categoryText(category: String, fallback: String): String =
+        items.filter { it.category == category }.joinToString("\n\n") { it.content }.ifBlank { fallback }
 
     private suspend fun rawRecords(projectId: String): List<LocalRecord> =
         loadSnapshot(projectId)
@@ -1027,6 +1106,7 @@ internal class MobileWorkspaceAgent(
     companion object {
         private const val MAX_ITERATIONS = 30
         private const val MAX_DRAFTS = 20
+        private const val MAX_CONTEXT_MANIFESTS = 20
         private val WORLD_DIMENSIONS = setOf("geography", "history", "factions", "power_system", "races", "culture")
         private val LOCATOR_FIELDS = setOf(
             "id", "project_id", "chapter_id", "chapter_title", "outline_node_id", "node_id",

--- a/mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt
+++ b/mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt
@@ -1,0 +1,247 @@
+package com.siming.mobile.data.agent
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class MobileContextManifestTest {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val policy: MobileContextPolicy by lazy {
+        val file = listOf(
+            File("app/src/main/assets/pc_context_manifest_policy.json"),
+            File("src/main/assets/pc_context_manifest_policy.json"),
+        ).first(File::isFile)
+        MobileContextPolicy.fromJson(json.parseToJsonElement(file.readText()) as JsonObject)
+    }
+
+    @Test
+    fun `manifest keeps style and target outline as required anchors`() {
+        val manifest = engine().prepare(inputs())
+
+        assertEquals("ready", manifest.status)
+        assertEquals(listOf("style", "target_outline"), manifest.items.take(2).map { it.category })
+        assertEquals("covered", manifest.coverage.getValue("style").status)
+        assertEquals("covered", manifest.coverage.getValue("target_outline").status)
+        assertTrue(manifest.inputBudgetTokens > manifest.estimatedInputTokens)
+    }
+
+    @Test
+    fun `missing target outline requires confirmation instead of writing blindly`() {
+        val manifest = engine().prepare(
+            inputs(request = request(outlineNodeId = "missing")),
+        )
+
+        assertEquals("needs_confirmation", manifest.status)
+        assertEquals("missing", manifest.coverage.getValue("target_outline").status)
+        assertTrue(manifest.warnings.any { "target_outline" in it })
+    }
+
+    @Test
+    fun `local lexical fallback selects relevant worldbuilding`() {
+        val manifest = engine().prepare(
+            inputs(request = request(requirements = "这一章要切断病毒网络并防止尸潮扩散")),
+        )
+
+        val world = manifest.items.filter { it.sourceType == "worldbuilding" }
+        assertTrue(world.isNotEmpty())
+        assertEquals("病毒网络", world.first().title)
+        assertTrue((world.first().lexicalScore ?: 0.0) > 0.0)
+        assertTrue("Lexical fallback" in world.first().selectionReason)
+    }
+
+    @Test
+    fun `alias resolution and directed relationships enter character source hash`() {
+        val manifest = engine().prepare(
+            inputs(request = request(involved = listOf("父亲"))),
+        )
+
+        val character = manifest.items.first { it.category == "scene_character" && it.title == "陆承宇" }
+        assertEquals("陆承宇", character.title)
+        assertTrue("陆糖: 父女" in character.content)
+        assertEquals(64, character.sourceHash.length)
+    }
+
+    @Test
+    fun `required anchors that exceed the hard budget are rejected`() {
+        val manifest = engine().prepare(
+            inputs(
+                styleText = "风".repeat(2_000),
+                contextWindowTokens = 3_000,
+            ),
+        )
+
+        assertEquals(440, manifest.inputBudgetTokens)
+        assertEquals("needs_confirmation", manifest.status)
+        assertEquals("missing", manifest.coverage.getValue("style").status)
+        assertTrue(manifest.estimatedInputTokens <= manifest.inputBudgetTokens)
+    }
+
+    @Test
+    fun `selected source changes make a cached manifest stale`() {
+        val engine = engine()
+        val beforeInputs = inputs(request = request(requirements = "病毒网络"))
+        val before = engine.prepare(beforeInputs)
+        val changedWorld = beforeInputs.rawRecords.map { row ->
+            if (row.string("id") == "w-virus") {
+                buildJsonObject {
+                    row.forEach { (key, value) -> put(key, value) }
+                    put("content", "病毒网络已经变异为会伪造角色记忆的新形态。")
+                }
+            } else {
+                row
+            }
+        }
+        val validation = engine.validate(
+            before,
+            beforeInputs.copy(rawRecords = changedWorld),
+        )
+
+        assertEquals("stale", validation.status)
+        assertNotEquals(before.selectionFingerprint, validation.current.selectionFingerprint)
+        assertTrue("来源发生变化" in validation.detail)
+    }
+
+    @Test
+    fun `model changes make a cached manifest stale`() {
+        val engine = engine()
+        val beforeInputs = inputs()
+        val before = engine.prepare(beforeInputs)
+        val validation = engine.validate(before, beforeInputs.copy(model = "another-model"))
+
+        assertEquals("stale", validation.status)
+        assertTrue("模型已从" in validation.detail)
+    }
+
+    @Test
+    fun `default manifest payload does not expose selected content`() {
+        val manifest = engine().prepare(inputs())
+        val compact = manifest.toJson()
+        val encoded = compact.toString()
+
+        assertFalse("rendered_context" in compact)
+        assertFalse("Character archive" in encoded)
+        assertFalse("会吞噬记忆" in encoded)
+        val items = compact["items"] as JsonArray
+        assertTrue(items.all { "content" !in (it as JsonObject) })
+    }
+
+    @Test
+    fun `token estimator mirrors PC CJK and non CJK heuristic`() {
+        assertEquals(4, estimateMobileTokens("天地玄黄"))
+        assertEquals(2, estimateMobileTokens("abcdefgh"))
+        assertEquals(4, estimateMobileTokens("天地abcdefgh"))
+    }
+
+    private fun engine() = MobileContextManifestEngine(policy)
+
+    private fun request(
+        outlineNodeId: String = "o1",
+        requirements: String = "寻找记忆城中的病毒线索",
+        involved: List<String> = listOf("陆糖"),
+    ) = MobileContextRequest(
+        outlineNodeId = outlineNodeId,
+        targetChapterId = "",
+        requirements = requirements,
+        involvedCharacters = involved,
+        characterLimit = 8,
+        recentLimit = 3,
+    )
+
+    private fun inputs(
+        request: MobileContextRequest = request(),
+        model: String = "deepseek-chat",
+        styleText: String = "第三人称；自然文风；不得改写角色专名。",
+        contextWindowTokens: Int? = null,
+    ): MobileContextInputs {
+        val project = buildJsonObject {
+            put("_record_type", "project")
+            put("id", "p1")
+            put("title", "记忆城")
+        }
+        val outline = buildJsonObject {
+            put("_record_type", "outline_node")
+            put("id", "o1")
+            put("title", "断线重连")
+            put("node_type", "chapter")
+            put("summary", "陆糖尝试切断病毒网络。")
+            put("status", "pending")
+            put("linked_characters", JsonArray(listOf(buildJsonObject { put("character_id", "c1") })))
+        }
+        val protagonist = character("c1", "陆糖", aliases = listOf("糖糖"))
+        val father = character("c2", "陆承宇", aliases = listOf("父亲"))
+        val relation = buildJsonObject {
+            put("_record_type", "character_relationship")
+            put("id", "r1")
+            put("from", "c2")
+            put("to", "c1")
+            put("relationship_type", "父女")
+            put("description", "互相信任")
+        }
+        val virus = world(
+            "w-virus",
+            "病毒网络",
+            "病毒会学习并通过凡人节点传播，切断网络后会引发尸潮。",
+            "2026-08-17T00:00:00Z",
+        )
+        val market = world(
+            "w-market",
+            "灵石市场",
+            "城内使用灵石交易，商会负责定价。",
+            "2026-08-16T00:00:00Z",
+        )
+        val chapter1 = chapter("ch1", "第一章", "陆糖进入记忆城。", 0)
+        val chapter2 = chapter("ch2", "第二章", "她发现病毒灰痕。", 1)
+        val raw = listOf(project, outline, protagonist, father, relation, virus, market, chapter1, chapter2)
+        return MobileContextInputs(
+            projectId = "p1",
+            model = model,
+            request = request,
+            project = project,
+            styleText = styleText,
+            primaryRecords = listOf(project, outline, protagonist, father, virus, market, chapter1, chapter2),
+            rawRecords = raw,
+            orderedChapters = listOf(chapter1, chapter2),
+            contextWindowTokens = contextWindowTokens,
+        )
+    }
+
+    private fun character(id: String, name: String, aliases: List<String>): JsonObject = buildJsonObject {
+        put("_record_type", "character")
+        put("id", id)
+        put("name", name)
+        put("role_type", "supporting")
+        put("personality", "稳定")
+        put("background", "记忆城居民")
+        put("appearance", "黑发")
+        put("abilities", JsonArray(listOf(JsonPrimitive("阵法"))))
+        put("aliases", JsonArray(aliases.map(::JsonPrimitive)))
+    }
+
+    private fun world(id: String, title: String, content: String, updatedAt: String): JsonObject = buildJsonObject {
+        put("_record_type", "world_entry")
+        put("id", id)
+        put("dimension", "culture")
+        put("title", title)
+        put("content", content)
+        put("updated_at", updatedAt)
+    }
+
+    private fun chapter(id: String, title: String, summary: String, sortOrder: Int): JsonObject = buildJsonObject {
+        put("_record_type", "chapter")
+        put("id", id)
+        put("title", title)
+        put("summary", summary)
+        put("sort_order", sortOrder)
+    }
+
+    private fun JsonObject.string(name: String): String = (get(name) as? JsonPrimitive)?.content.orEmpty()
+}

--- a/mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt
+++ b/mobile/android/app/src/test/java/com/siming/mobile/data/agent/MobileContextManifestTest.kt
@@ -136,7 +136,7 @@ class MobileContextManifestTest {
 
     @Test
     fun `token estimator mirrors PC CJK and non CJK heuristic`() {
-        assertEquals(4, estimateMobileTokens("天地玄黄"))
+        assertEquals(5, estimateMobileTokens("天地玄黄"))
         assertEquals(2, estimateMobileTokens("abcdefgh"))
         assertEquals(4, estimateMobileTokens("天地abcdefgh"))
     }

--- a/scripts/export-mobile-context-policy.py
+++ b/scripts/export-mobile-context-policy.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Export the PC writing-context policy consumed by Android standalone mode."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.services.mobile_context_policy import portable_context_policy  # noqa: E402
+
+DEFAULT_OUTPUT = (
+    ROOT
+    / "mobile"
+    / "android"
+    / "app"
+    / "src"
+    / "main"
+    / "assets"
+    / "pc_context_manifest_policy.json"
+)
+
+
+def _canonical(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def build_policy() -> dict[str, Any]:
+    payload = portable_context_policy("writing")
+    payload["source_sha256"] = hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()
+    return payload
+
+
+def render_policy(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    output = args.output if args.output.is_absolute() else ROOT / args.output
+    expected = render_policy(build_policy())
+    if args.check:
+        actual = output.read_text(encoding="utf-8") if output.is_file() else ""
+        if actual != expected:
+            print(f"generated Android context policy is stale: {output}", file=sys.stderr)
+            return 1
+        return 0
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(expected, encoding="utf-8")
+    print(output.relative_to(ROOT))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 目标

让 Android 独立 Agent 在调用模型写章之前，消费由 PC 权威上下文策略导出的便携 `ContextManifest`，不再依赖手机端自成体系的上下文拼装。

本 PR 直接基于已合并的 #31，分支历史只有一个正式功能提交，不包含源码分片、临时导出工作流或传输修复提交。

## 已实现

- 新增 PC 便携策略投影与导出脚本，生成版本化 Android 策略资产。
- 新增 Android `MobileContextManifest` 引擎：必选锚点、确定性本地检索、token 预算、tier、排序去重、coverage、warnings、来源哈希及请求/选择指纹。
- `preview_writing_context` 生成并缓存清单；`chapter_writer` 在调用模型前复用或重建并校验。
- 缺少目标大纲/风格，或作品、模型、请求、策略、索引、来源发生变化时，返回 `needs_confirmation` / `stale`，不盲目继续写章。
- compact manifest 不携带完整作品正文。
- 更新 Android / PC 能力契约、生成文档与 Architecture CI 策略资产漂移检查。
- 新增后端和 Android 回归测试。

## 明确降级

手机独立模式当前仍仅使用本地词法检索与会话级缓存，不伪装为 PC 的 FTS、向量检索、pinned chunks 或持久审计。

## 本地验证

- `python scripts/export-mobile-context-policy.py --check`
- `python scripts/check-mobile-pc-parity.py --check-doc docs/mobile-pc-parity.md`
- 相关 Python 回归测试：25 passed
- `python -m compileall -q ...`
- `git diff --check`

本地隔离环境无法解析 Gradle 分发域名，因此 Android 编译、lint、单元测试和 Debug APK 由本 PR 的 GitHub CI 完成。
