### PR TITLE
临时清理 Android 章节工作区分支

### DIFF
--- a/.github/workflows/cleanup-android-chapter-workspace-temporary.yml
+++ b/.github/workflows/cleanup-android-chapter-workspace-temporary.yml
@@ -1,0 +1,30 @@
+name: Temporary cleanup Android chapter workspace branch
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.ref == 'cleanup/android-chapter-workspace-20260819'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Verify squash result and delete temporary branches
+        run: |
+          set -euo pipefail
+          expected_develop='64ee4b4b8b4f8d8d246cffe2d0c31a7bf72007e7'
+          expected_feature='98ecf03dafb7596553c7a1a82c2e3f29d475cfe6'
+          test "$(git rev-parse HEAD)" = "$expected_develop"
+          git fetch origin feature/android-chapter-workspace
+          test "$(git rev-parse FETCH_HEAD)" = "$expected_feature"
+          git push origin --delete feature/android-chapter-workspace
+          git push origin --delete cleanup/android-chapter-workspace-20260819


### PR DESCRIPTION
临时维护 PR。cleanup run `32214189745` 已验证 develop 精确为 `64ee4b4b8b4f8d8d246cffe2d0c31a7bf72007e7`，并验证 PR #42 feature head 精确为 `98ecf03dafb7596553c7a1a82c2e3f29d475cfe6` 后，已删除 `feature/android-chapter-workspace` 与本 cleanup 分支。此 PR 未合入 develop。