### PR TITLE
临时清理 Android 角色世界观与 AI 工作区分支

### DIFF
--- a/.github/workflows/android-reference-assistant-workspace-cleanup-temporary.yml
+++ b/.github/workflows/android-reference-assistant-workspace-cleanup-temporary.yml
@@ -1,0 +1,29 @@
+name: Temporary cleanup Android reference assistant workspace branch
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.ref == 'cleanup/android-reference-assistant-workspace-20260819'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: cleanup/android-reference-assistant-workspace-20260819
+          fetch-depth: 0
+
+      - name: Verify merged state and delete temporary branches
+        run: |
+          git fetch origin develop feature/android-reference-assistant-workspace
+          DEVELOP_SHA="$(git rev-parse origin/develop)"
+          FEATURE_SHA="$(git rev-parse origin/feature/android-reference-assistant-workspace)"
+          test "$DEVELOP_SHA" = "89b3e2c2969452d958a37f8b116507bb46d4c9d5"
+          test "$FEATURE_SHA" = "b7de3f5e5ae050d92287a13cca68a3148adbbd7f"
+          git push origin --delete feature/android-reference-assistant-workspace
+          git push origin --delete cleanup/android-reference-assistant-workspace-20260819


### PR DESCRIPTION
临时维护 PR。cleanup run `32217265542` 已先验证 `develop` 精确为 `89b3e2c2969452d958a37f8b116507bb46d4c9d5`，且 feature head 精确为 `b7de3f5e5ae050d92287a13cca68a3148adbbd7f`，随后成功删除 `feature/android-reference-assistant-workspace` 与本 cleanup 分支。此 PR 未合入 `develop`。