### PR TITLE
修复作品建档反复缺候选并改为累计式自动补全

### DIFF
--- a/backend/app/services/cataloging/__init__.py
+++ b/backend/app/services/cataloging/__init__.py
@@ -1,1 +1,7 @@
 """Project cataloging pipeline."""
+
+from .runtime_repair import install_cataloging_runtime_repairs
+
+install_cataloging_runtime_repairs()
+
+__all__ = ["install_cataloging_runtime_repairs"]

--- a/backend/app/services/cataloging/repair_identity.py
+++ b/backend/app/services/cataloging/repair_identity.py
@@ -1,0 +1,178 @@
+"""Identity helpers for cataloging completeness repair."""
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from typing import Any
+
+ANONYMOUS_CHARACTER_EXACT = {
+    "人影",
+    "身影",
+    "黑影",
+    "神秘人影",
+    "神秘身影",
+    "陌生人",
+    "陌生人影",
+    "陌生声音",
+    "神秘声音",
+    "未知声音",
+    "无名者",
+    "来人",
+    "访客",
+    "袭击者",
+    "追兵",
+    "蒙面人",
+    "黑衣人",
+    "斗篷人",
+}
+ANONYMOUS_CHARACTER_PATTERN = re.compile(
+    r"^(?:神秘|陌生|未知|不明|模糊|黑衣|蒙面|斗篷|无名|某)"
+    r"(?:人|人影|身影|声音|女子|男子|老人|少年|少女|修士|来客|存在|角色|者)?"
+    r"(?:[甲乙丙丁]|\d+)?$"
+)
+TRAILING_DESCRIPTOR = re.compile(
+    r"(?:[（(【\[][^（）()【】\[\]]{2,80}[）)】\]])+$"
+)
+STABLE_PROFILE_FIELDS = {
+    "aliases",
+    "role_type",
+    "personality",
+    "background",
+    "abilities",
+    "tone_style",
+    "catchphrases",
+    "verbosity",
+    "emotion_tendency",
+    "custom_system_prompt",
+    "profile",
+    "profile_json",
+    "ai_config",
+}
+
+
+def identity(value: Any) -> str:
+    return re.sub(r"\s+", "", str(value or "").strip()).casefold()
+
+
+def worldbuilding_base(value: Any) -> str:
+    raw = identity(value)
+    if not raw:
+        return ""
+    base = TRAILING_DESCRIPTOR.sub("", raw).strip("-—:：·")
+    return base or raw
+
+
+def is_anonymous_character(value: Any) -> bool:
+    raw = identity(value)
+    return bool(
+        raw
+        and (
+            raw in ANONYMOUS_CHARACTER_EXACT
+            or ANONYMOUS_CHARACTER_PATTERN.fullmatch(raw)
+        )
+    )
+
+
+def candidate_payload(item: Any) -> dict[str, Any]:
+    if isinstance(item, dict):
+        value = item.get("payload") if isinstance(item.get("payload"), dict) else item
+        return dict(value)
+    raw = getattr(item, "edited_payload", None) or getattr(item, "raw_payload", None)
+    if isinstance(raw, dict):
+        return dict(raw)
+    try:
+        value = json.loads(raw or "{}")
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def candidate_type(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("item_type") or item.get("type") or "").strip()
+    return str(getattr(item, "item_type", "") or "").strip()
+
+
+def meaningful(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(meaningful(item) for item in value.values())
+    if isinstance(value, (list, tuple, set)):
+        return any(meaningful(item) for item in value)
+    return bool(str(value or "").strip())
+
+
+def has_stable_profile_evidence(payload: dict[str, Any]) -> bool:
+    return any(meaningful(payload.get(key)) for key in STABLE_PROFILE_FIELDS)
+
+
+def candidate_character_name(item: Any) -> str:
+    payload = candidate_payload(item)
+    return identity(
+        payload.get("name")
+        or payload.get("character_name")
+        or payload.get("target_name")
+        or getattr(item, "target_name", "")
+    )
+
+
+def worldbuilding_alias_map(
+    values: Iterable[str],
+    declared: set[str],
+    existing: set[str],
+) -> dict[str, str]:
+    values = {value for value in values if value}
+    by_base: dict[str, set[str]] = {}
+    for value in values:
+        by_base.setdefault(worldbuilding_base(value), set()).add(value)
+
+    aliases = {value: value for value in values}
+    for base, variants in by_base.items():
+        canonical = ""
+        if base in declared:
+            canonical = base
+        elif base in existing and len(variants & declared) == 1:
+            canonical = base
+        if canonical:
+            for variant in variants:
+                aliases[variant] = canonical
+    return aliases
+
+
+def canonicalize(values: Iterable[str], aliases: dict[str, str]) -> set[str]:
+    return {aliases.get(value, value) for value in values if value}
+
+
+def split_diagnostic_identities(item: str, prefix: str) -> list[str] | None:
+    if not item.startswith(prefix):
+        return None
+    _, separator, detail = item.partition(": ")
+    if not separator:
+        return []
+    return [part.strip() for part in detail.split("、") if part.strip()]
+
+
+def filter_diagnostics(
+    items: Iterable[str],
+    *,
+    prefixes: tuple[str, ...],
+    excluded: set[str],
+) -> tuple[str, ...]:
+    result: list[str] = []
+    for item in items:
+        replacement: str | None = None
+        matched = False
+        for prefix in prefixes:
+            identities = split_diagnostic_identities(item, prefix)
+            if identities is None:
+                continue
+            matched = True
+            kept = [name for name in identities if identity(name) not in excluded]
+            if kept:
+                replacement = f"{prefix}: " + "、".join(kept)
+            break
+        if replacement:
+            result.append(replacement)
+        elif not matched:
+            result.append(item)
+    return tuple(result)

--- a/backend/app/services/cataloging/runtime_repair.py
+++ b/backend/app/services/cataloging/runtime_repair.py
@@ -1,476 +1,511 @@
-"""Runtime repairs for cataloging candidate completeness.
+"""Shared runtime policy for repairing incomplete cataloging candidates.
 
-The cataloging pipeline streams useful candidates before it knows whether the
-whole chapter satisfies the coverage contract. Providers often omit one or
-two trailing cards, vary an identity label, or stop after a long response. A
-full retry used to delete the valid cards and could fail again on a different
-item. This module installs one shared repair policy for internal API, local
-CLI, PC Gateway, and Android-triggered cataloging:
+Providers commonly omit a trailing card or vary one identity label. This
+module keeps valid cards, reconciles deterministic identity differences, and
+turns every remaining hard gap into an incremental repair turn.
 
-* keep valid staged candidates while a repair turn is running;
-* retry every remaining hard coverage gap with exact missing identities;
-* canonicalize harmless worldbuilding title decorations;
-* accept existing unchanged settings when they are linked to the chapter;
-* keep anonymous/unknown figures chapter-local instead of forcing blank cards;
-* move surplus candidate identities to review warnings instead of blocking.
-
-The hooks are installed from ``cataloging.__init__`` before the orchestrator
-imports these functions. Keeping the policy in one module makes the behavior
-identical for all front ends while avoiding a second mobile-only validator.
+Cataloging submodules are loaded dynamically so installation from the package
+initializer does not introduce a static import cycle.
 """
 from __future__ import annotations
 
-import re
+from collections.abc import Callable, Iterable
 from dataclasses import replace
-from typing import Any, Iterable
+from importlib import import_module
+from typing import Any
 
 from ...database.models import CatalogingCandidate, Character, WorldbuildingEntry
-from .. import story_granularity as granularity
-from . import candidate_store
-from . import candidate_validation as validation
-from . import fact_store, staged_prompts
+from .repair_identity import (
+    candidate_character_name,
+    candidate_payload,
+    candidate_type,
+    canonicalize,
+    filter_diagnostics,
+    has_stable_profile_evidence,
+    identity,
+    is_anonymous_character,
+    worldbuilding_alias_map,
+)
 
 _INSTALLED = False
+_ORIGINAL_INSPECT: Callable[..., Any] | None = None
+_ORIGINAL_ERROR_MESSAGE: Callable[..., str] | None = None
+_ORIGINAL_REVIEW_MESSAGE: Callable[..., str] | None = None
+_ORIGINAL_CLEAR_CANDIDATES: Callable[..., None] | None = None
+_ORIGINAL_TRY_CREATE_CANDIDATES: Callable[..., list[dict[str, Any]]] | None = None
+_ORIGINAL_PROFILE_CHECK: Callable[[dict[str, Any]], bool] | None = None
+_ORIGINAL_CANDIDATE_RULES: Callable[[], str] | None = None
 
-_REPAIR_PROMPT = r"""
+_REPAIR_PROMPT = """
 【候选缺项自动修复】
-- 当用户消息包含“上一轮校验未通过”时，这是增量修复回合。系统会保留上一轮已经通过的候选；只补充错误信息明确指出的缺失身份，或修正身份不一致的候选，不要为了重试删除、缩减或改写已有正确卡片。
-- 结束前逐项核对 coverage_manifest 与候选：characters 对应 character_state_update；worldbuilding 中真正新增、变化、确认、受损、受限或被使用的设定对应 worldbuilding_create/update/timeline；character_profiles 对应 character_create/update；relationships 对应 character_relationship；每个角色和设定都有 chapter_link。
-- 已存在且本章只是引用、没有新增或变化的世界观，不要虚构 update；保留其清单身份并输出同标题 chapter_link 即可。
-- coverage_manifest 中的名称必须与候选 name/title 完全一致。说明性后缀放进 content/description，不要把“系统”改写成“系统（无界面·无沟通·自行探索型）”之类的新标题。
-- “神秘人影、陌生声音、黑影、蒙面人”等尚无稳定身份的描述，只作为本章出场线索和 chapter_link/摘要信息；除非正文已提供可持续使用的稳定档案，否则不要放入 character_profiles，也不要创建空白永久角色卡。
-- 如果输出很长，优先保证清单中每个身份都有对应候选，再补充非必需时间线与说明；不得在已经声明完整清单后提前结束。
+- 当用户消息包含“上一轮校验未通过”时，这是增量修复回合。系统会保留上一轮已经
+  通过的候选；只补充错误信息明确指出的缺失身份，或修正身份不一致的候选，不要
+  删除、缩减或改写已有正确卡片。
+- 结束前逐项核对 coverage_manifest 与候选：角色对应 character_state_update；
+  真正变化的设定对应 worldbuilding_create/update/timeline；角色资料对应
+  character_create/update；关系对应 character_relationship；每个角色和设定都有
+  chapter_link。
+- 已存在且本章只是引用、没有新增或变化的世界观，不要虚构 update；保留其清单
+  身份并输出同标题 chapter_link 即可。
+- coverage_manifest 中的名称必须与候选 name/title 完全一致。说明性后缀放进
+  content/description，不要把“系统”改写成带说明性括号后缀的新标题。
+- “神秘人影、陌生声音、黑影、蒙面人”等尚无稳定身份的描述，只作为本章线索；
+  除非正文已提供可持续使用的稳定档案，否则不要创建空白永久角色卡。
+- 如果输出很长，优先保证清单中每个身份都有对应候选，再补充非必需时间线与说明。
 """.strip()
 
-_ANONYMOUS_CHARACTER_EXACT = {
-    "人影",
-    "身影",
-    "黑影",
-    "神秘人影",
-    "神秘身影",
-    "陌生人",
-    "陌生人影",
-    "陌生声音",
-    "神秘声音",
-    "未知声音",
-    "无名者",
-    "来人",
-    "访客",
-    "袭击者",
-    "追兵",
-    "蒙面人",
-    "黑衣人",
-    "斗篷人",
-}
-_ANONYMOUS_CHARACTER_PATTERN = re.compile(
-    r"^(?:神秘|陌生|未知|不明|模糊|黑衣|蒙面|斗篷|无名|某)"
-    r"(?:人|人影|身影|声音|女子|男子|老人|少年|少女|修士|来客|存在|角色|者)?"
-    r"(?:[甲乙丙丁]|\d+)?$"
-)
-_TRAILING_DESCRIPTOR = re.compile(
-    r"(?:[（(【\[][^（）()【】\[\]]{2,80}[）)】\]])+$"
-)
+
+def _load_existing_identities(
+    db: Any,
+    project_id: str | None,
+) -> tuple[set[str], set[str]]:
+    if db is None or not project_id:
+        return set(), set()
+    worldbuilding = {
+        identity(row.title)
+        for row in db.query(WorldbuildingEntry)
+        .filter(WorldbuildingEntry.project_id == project_id)
+        .all()
+        if identity(row.title)
+    }
+    characters = {
+        identity(row.name)
+        for row in db.query(Character)
+        .filter(Character.project_id == project_id)
+        .all()
+        if identity(row.name)
+    }
+    return worldbuilding, characters
 
 
-def _identity(value: Any) -> str:
-    return re.sub(r"\s+", "", str(value or "").strip()).casefold()
-
-
-def _worldbuilding_base(value: Any) -> str:
-    raw = _identity(value)
-    if not raw:
-        return ""
-    base = _TRAILING_DESCRIPTOR.sub("", raw).strip("-—:：·")
-    return base or raw
-
-
-def _is_unresolved_character(value: Any) -> bool:
-    raw = _identity(value)
-    if not raw:
-        return False
-    return raw in _ANONYMOUS_CHARACTER_EXACT or bool(
-        _ANONYMOUS_CHARACTER_PATTERN.fullmatch(raw)
-    )
-
-
-def _split_diagnostic_identities(item: str, prefix: str) -> list[str] | None:
-    if not item.startswith(prefix):
-        return None
-    _, separator, detail = item.partition(": ")
-    if not separator:
-        return []
-    return [part.strip() for part in detail.split("、") if part.strip()]
-
-
-def _filter_diagnostic_identities(
-    items: Iterable[str],
-    *,
-    prefixes: tuple[str, ...],
-    excluded: set[str],
-) -> tuple[str, ...]:
-    result: list[str] = []
+def _anonymous_with_stable_cards(items: Iterable[Any]) -> set[str]:
+    result: set[str] = set()
     for item in items:
-        replaced = False
-        for prefix in prefixes:
-            identities = _split_diagnostic_identities(item, prefix)
-            if identities is None:
-                continue
-            kept = [name for name in identities if _identity(name) not in excluded]
-            if kept:
-                result.append(f"{prefix}: " + "、".join(kept))
-            replaced = True
-            break
-        if not replaced:
-            result.append(item)
-    return tuple(result)
-
-
-def _worldbuilding_alias_map(
-    values: Iterable[str],
-    declared: set[str],
-) -> dict[str, str]:
-    values = {item for item in values if item}
-    by_base: dict[str, set[str]] = {}
-    for value in values:
-        by_base.setdefault(_worldbuilding_base(value), set()).add(value)
-
-    result = {value: value for value in values}
-    for base, variants in by_base.items():
-        declared_variants = variants & declared
-        if len(declared_variants) == 1:
-            canonical = next(iter(declared_variants))
-        elif base in variants:
-            canonical = base
-        elif len(variants) == 1:
-            canonical = next(iter(variants))
-        else:
-            # Ambiguous decorated titles remain separate and require review.
+        if candidate_type(item) not in {"character_create", "character_update"}:
             continue
-        for variant in variants:
-            result[variant] = canonical
+        name = candidate_character_name(item)
+        payload = candidate_payload(item)
+        if name and is_anonymous_character(name) and has_stable_profile_evidence(payload):
+            result.add(name)
     return result
 
 
-def _canonicalize(values: Iterable[str], aliases: dict[str, str]) -> set[str]:
-    return {aliases.get(value, value) for value in values if value}
+def _reject_weak_anonymous_cards(items: Iterable[Any], unresolved: set[str]) -> bool:
+    changed = False
+    for item in items:
+        if candidate_type(item) not in {"character_create", "character_update"}:
+            continue
+        if candidate_character_name(item) not in unresolved:
+            continue
+        if isinstance(item, dict):
+            if item.get("status") != "rejected":
+                item["status"] = "rejected"
+                item["error"] = "身份未确认且缺少稳定档案，已保留为章节线索"
+                changed = True
+            continue
+        if str(getattr(item, "status", "") or "") != "rejected":
+            item.status = "rejected"
+            item.error = "身份未确认且缺少稳定档案，已保留为章节线索"
+            changed = True
+    return changed
 
 
-def _diagnostic_details(coverage: granularity.CandidateCoverage) -> list[str]:
-    details: list[str] = []
-    missing_states = set(coverage.declared_character_identities) - set(
-        coverage.character_state_identities
+def _append_extra_warning(
+    warnings: list[str],
+    values: set[str],
+    label: str,
+) -> None:
+    if values:
+        warnings.append(label + "：" + "、".join(sorted(values)))
+
+
+def _review_warnings_for_extras(
+    *,
+    extra_states: set[str],
+    extra_profiles: set[str],
+    extra_relationships: set[str],
+    extra_worldbuilding: set[str],
+    extra_character_links: set[str],
+    extra_worldbuilding_links: set[str],
+    unresolved: set[str],
+) -> list[str]:
+    warnings: list[str] = []
+    _append_extra_warning(
+        warnings,
+        extra_states,
+        "角色状态候选未写入 coverage_manifest.characters",
     )
-    missing_worldbuilding = set(coverage.declared_worldbuilding_identities) - set(
-        coverage.worldbuilding_candidate_identities
+    _append_extra_warning(
+        warnings,
+        extra_profiles,
+        "角色资料候选未写入 coverage_manifest.character_profiles",
     )
-    missing_relationships = set(coverage.declared_relationship_identities) - set(
-        coverage.relationship_candidate_identities
+    _append_extra_warning(
+        warnings,
+        extra_relationships,
+        "角色关系候选未写入 coverage_manifest.relationships",
     )
-    missing_profiles = set(coverage.declared_character_profile_identities) - set(
-        coverage.character_profile_candidate_identities
+    _append_extra_warning(
+        warnings,
+        extra_worldbuilding,
+        "世界观候选未写入 coverage_manifest.worldbuilding",
     )
-    missing_character_links = set(coverage.declared_character_identities) - set(
-        coverage.chapter_link_character_identities
+    _append_extra_warning(warnings, extra_character_links, "章节关联包含清单外角色")
+    _append_extra_warning(
+        warnings,
+        extra_worldbuilding_links,
+        "章节关联包含清单外世界观",
     )
-    missing_worldbuilding_links = set(coverage.declared_worldbuilding_identities) - set(
-        coverage.chapter_link_worldbuilding_identities
+    _append_extra_warning(
+        warnings,
+        unresolved,
+        "身份未确认角色按章节线索保留，不强制建立永久角色卡",
     )
-    if missing_states:
-        details.append("缺少角色状态候选：" + "、".join(sorted(missing_states)))
-    if missing_worldbuilding:
-        details.append(
-            "缺少世界观候选或既有设定关联："
-            + "、".join(sorted(missing_worldbuilding))
-        )
-    if missing_relationships:
-        details.append("缺少角色关系候选：" + "、".join(sorted(missing_relationships)))
-    if missing_profiles:
-        details.append("缺少角色资料候选：" + "、".join(sorted(missing_profiles)))
-    if missing_character_links:
-        details.append("缺少角色章节关联：" + "、".join(sorted(missing_character_links)))
-    if missing_worldbuilding_links:
-        details.append(
-            "缺少世界观章节关联：" + "、".join(sorted(missing_worldbuilding_links))
-        )
-    return details
+    return warnings
 
 
-def install_cataloging_runtime_repairs() -> None:
-    """Install one idempotent completeness/repair policy for cataloging."""
+def _reconcile_worldbuilding(
+    coverage: Any,
+    existing: set[str],
+) -> tuple[set[str], set[str], set[str], set[str]]:
+    declared = set(coverage.declared_worldbuilding_identities)
+    candidates = set(coverage.worldbuilding_candidate_identities)
+    links = set(coverage.chapter_link_worldbuilding_identities)
+    aliases = worldbuilding_alias_map(
+        declared | candidates | links | existing,
+        declared,
+        existing,
+    )
+    declared = canonicalize(declared, aliases)
+    candidates = canonicalize(candidates, aliases)
+    links = canonicalize(links, aliases)
+    existing = canonicalize(existing, aliases)
+    linked_existing = declared & links & existing
+    return declared, candidates | linked_existing, links, candidates
 
-    global _INSTALLED
-    if _INSTALLED:
-        return
-    _INSTALLED = True
 
-    original_inspect = validation.inspect_candidate_coverage
-    original_error_message = validation.candidate_coverage_error_message
-    original_review_message = validation.candidate_coverage_review_message
-    original_clear_candidates = fact_store.clear_candidates_for_run
-    original_try_create_candidates = candidate_store.try_create_candidates
-    original_profile_check = granularity._has_meaningful_character_profile
-    original_candidate_rules = None
+def _candidate_sets(coverage: Any) -> dict[str, set[str]]:
+    return {
+        "declared_characters": set(coverage.declared_character_identities),
+        "states": set(coverage.character_state_identities),
+        "declared_profiles": set(coverage.declared_character_profile_identities),
+        "profiles": set(coverage.character_profile_candidate_identities),
+        "declared_relationships": set(coverage.declared_relationship_identities),
+        "relationships": set(coverage.relationship_candidate_identities),
+        "character_links": set(coverage.chapter_link_character_identities),
+    }
 
-    try:
-        from ...prompts import cataloging_source
 
-        original_candidate_rules = cataloging_source.get_cataloging_candidate_rules
-    except Exception:  # pragma: no cover - prompt module is always present in production
-        cataloging_source = None
+def _reconciled_coverage(
+    coverage: Any,
+    *,
+    sets: dict[str, set[str]],
+    worldbuilding: tuple[set[str], set[str], set[str], set[str]],
+    unresolved: set[str],
+) -> Any:
+    declared_worldbuilding, covered_worldbuilding, worldbuilding_links, raw_world = (
+        worldbuilding
+    )
+    declared_characters = sets["declared_characters"]
+    states = sets["states"]
+    declared_profiles = sets["declared_profiles"] - unresolved
+    profiles = sets["profiles"]
+    declared_relationships = sets["declared_relationships"]
+    relationships = sets["relationships"]
+    character_links = sets["character_links"]
 
-    def inspect_candidate_coverage(
-        candidates: Iterable[Any],
-        *,
-        db: Any = None,
-        project_id: str | None = None,
-    ) -> granularity.CandidateCoverage:
-        items = list(candidates)
-        coverage = original_inspect(items, db=db, project_id=project_id)
+    extras = _review_warnings_for_extras(
+        extra_states=states - declared_characters,
+        extra_profiles=profiles - declared_profiles,
+        extra_relationships=relationships - declared_relationships,
+        extra_worldbuilding=raw_world - declared_worldbuilding,
+        extra_character_links=character_links - declared_characters,
+        extra_worldbuilding_links=worldbuilding_links - declared_worldbuilding,
+        unresolved=unresolved,
+    )
+    persistence_missing = filter_diagnostics(
+        coverage.persistence_missing,
+        prefixes=(
+            "character_create/update for new declared characters",
+            "relationship endpoints without character profiles",
+        ),
+        excluded=unresolved,
+    )
+    states &= declared_characters
+    profiles &= declared_profiles
+    relationships &= declared_relationships
+    character_links &= declared_characters
+    covered_worldbuilding &= declared_worldbuilding
+    worldbuilding_links &= declared_worldbuilding
+    review_warnings = tuple(dict.fromkeys([*coverage.review_warnings, *extras]))
 
-        declared_characters = set(coverage.declared_character_identities)
-        character_states = set(coverage.character_state_identities)
-        declared_profiles = set(coverage.declared_character_profile_identities)
-        profile_candidates = set(coverage.character_profile_candidate_identities)
-        declared_relationships = set(coverage.declared_relationship_identities)
-        relationship_candidates = set(coverage.relationship_candidate_identities)
-        character_links = set(coverage.chapter_link_character_identities)
+    return replace(
+        coverage,
+        declared_character_profile_count=len(declared_profiles),
+        character_state_count=len(states),
+        worldbuilding_candidate_count=len(covered_worldbuilding),
+        relationship_candidate_count=len(relationships),
+        character_profile_candidate_count=len(profiles),
+        declared_worldbuilding_count=len(declared_worldbuilding),
+        declared_character_profile_identities=tuple(sorted(declared_profiles)),
+        character_state_identities=tuple(sorted(states)),
+        worldbuilding_candidate_identities=tuple(sorted(covered_worldbuilding)),
+        relationship_candidate_identities=tuple(sorted(relationships)),
+        character_profile_candidate_identities=tuple(sorted(profiles)),
+        declared_worldbuilding_identities=tuple(sorted(declared_worldbuilding)),
+        chapter_link_character_identities=tuple(sorted(character_links)),
+        chapter_link_worldbuilding_identities=tuple(sorted(worldbuilding_links)),
+        persistence_missing=persistence_missing,
+        review_warnings=review_warnings,
+    )
 
-        declared_worldbuilding = set(coverage.declared_worldbuilding_identities)
-        worldbuilding_candidates = set(coverage.worldbuilding_candidate_identities)
-        worldbuilding_links = set(coverage.chapter_link_worldbuilding_identities)
-        existing_worldbuilding: set[str] = set()
-        existing_characters: set[str] = set()
-        if db is not None and project_id:
-            existing_worldbuilding = {
-                _identity(row.title)
-                for row in db.query(WorldbuildingEntry)
-                .filter(WorldbuildingEntry.project_id == project_id)
-                .all()
-                if _identity(row.title)
-            }
-            existing_characters = {
-                _identity(row.name)
-                for row in db.query(Character)
-                .filter(Character.project_id == project_id)
-                .all()
-                if _identity(row.name)
-            }
 
-        world_values = (
-            declared_worldbuilding
-            | worldbuilding_candidates
-            | worldbuilding_links
-            | existing_worldbuilding
-        )
-        world_aliases = _worldbuilding_alias_map(
-            world_values,
-            declared_worldbuilding,
-        )
-        declared_worldbuilding = _canonicalize(
-            declared_worldbuilding,
-            world_aliases,
-        )
-        worldbuilding_candidates = _canonicalize(
-            worldbuilding_candidates,
-            world_aliases,
-        )
-        worldbuilding_links = _canonicalize(worldbuilding_links, world_aliases)
-        existing_worldbuilding = _canonicalize(
-            existing_worldbuilding,
-            world_aliases,
-        )
-
-        # A pre-existing setting that is merely referenced does not need a fake
-        # update card. Its same-title chapter_link is the persistence action.
-        linked_existing = (
-            declared_worldbuilding & worldbuilding_links & existing_worldbuilding
-        )
-        covered_worldbuilding = worldbuilding_candidates | linked_existing
-
-        extra_states = character_states - declared_characters
-        extra_profiles = profile_candidates - declared_profiles
-        extra_relationships = relationship_candidates - declared_relationships
-        extra_worldbuilding = worldbuilding_candidates - declared_worldbuilding
-        extra_character_links = character_links - declared_characters
-        extra_worldbuilding_links = worldbuilding_links - declared_worldbuilding
-
-        unresolved_characters = {
-            identity
-            for identity in declared_characters
-            if identity not in existing_characters and _is_unresolved_character(identity)
-        }
-        declared_profiles -= unresolved_characters
-
-        review_warnings = list(coverage.review_warnings)
-        if extra_states:
-            review_warnings.append(
-                "角色状态候选未写入 coverage_manifest.characters："
-                + "、".join(sorted(extra_states))
-            )
-        if extra_profiles:
-            review_warnings.append(
-                "角色资料候选未写入 coverage_manifest.character_profiles："
-                + "、".join(sorted(extra_profiles))
-            )
-        if extra_relationships:
-            review_warnings.append(
-                "角色关系候选未写入 coverage_manifest.relationships："
-                + "、".join(sorted(extra_relationships))
-            )
-        if extra_worldbuilding:
-            review_warnings.append(
-                "世界观候选未写入 coverage_manifest.worldbuilding："
-                + "、".join(sorted(extra_worldbuilding))
-            )
-        if extra_character_links:
-            review_warnings.append(
-                "章节关联包含清单外角色：" + "、".join(sorted(extra_character_links))
-            )
-        if extra_worldbuilding_links:
-            review_warnings.append(
-                "章节关联包含清单外世界观："
-                + "、".join(sorted(extra_worldbuilding_links))
-            )
-        if unresolved_characters:
-            review_warnings.append(
-                "身份未确认角色按章节线索保留，不强制建立永久角色卡："
-                + "、".join(sorted(unresolved_characters))
-            )
-
-        persistence_missing = _filter_diagnostic_identities(
-            coverage.persistence_missing,
-            prefixes=(
-                "character_create/update for new declared characters",
-                "relationship endpoints without character profiles",
-            ),
-            excluded=unresolved_characters,
-        )
-
-        # Surplus cards are useful data and should be reviewed, not treated as
-        # data loss. Contract counts below only include declared identities.
-        character_states &= declared_characters
-        profile_candidates &= declared_profiles
-        relationship_candidates &= declared_relationships
-        character_links &= declared_characters
-        covered_worldbuilding &= declared_worldbuilding
-        worldbuilding_links &= declared_worldbuilding
-
-        return replace(
-            coverage,
-            declared_character_profile_count=len(declared_profiles),
-            character_state_count=len(character_states),
-            worldbuilding_candidate_count=len(covered_worldbuilding),
-            relationship_candidate_count=len(relationship_candidates),
-            character_profile_candidate_count=len(profile_candidates),
-            declared_worldbuilding_count=len(declared_worldbuilding),
-            declared_character_profile_identities=tuple(sorted(declared_profiles)),
-            character_state_identities=tuple(sorted(character_states)),
-            worldbuilding_candidate_identities=tuple(sorted(covered_worldbuilding)),
-            relationship_candidate_identities=tuple(sorted(relationship_candidates)),
-            character_profile_candidate_identities=tuple(sorted(profile_candidates)),
-            declared_worldbuilding_identities=tuple(sorted(declared_worldbuilding)),
-            chapter_link_character_identities=tuple(sorted(character_links)),
-            chapter_link_worldbuilding_identities=tuple(sorted(worldbuilding_links)),
-            persistence_missing=persistence_missing,
-            review_warnings=tuple(dict.fromkeys(review_warnings)),
-        )
-
-    def candidate_coverage_should_retry(
-        coverage: granularity.CandidateCoverage,
-    ) -> bool:
-        # After deterministic reconciliation, every remaining hard gap is a
-        # real missing card and should receive an incremental model repair turn.
-        return bool(coverage.cli_parity_missing)
-
-    def candidate_coverage_error_message(
-        coverage: granularity.CandidateCoverage,
-        *,
-        prefix: str = "候选覆盖不完整",
-    ) -> str:
-        base = original_error_message(coverage, prefix=prefix)
-        details = _diagnostic_details(coverage)
-        return base if not details else base + "；" + "；".join(details)
-
-    def candidate_coverage_review_message(
-        coverage: granularity.CandidateCoverage,
-    ) -> str:
-        return original_review_message(coverage)
-
-    def clear_candidates_for_run(db: Any, run: Any) -> None:
-        # The first pass has no cards. Any later call while extracting is a
-        # repair/retry pass, so retain its valid staged cards and merge fixes.
-        existing = (
-            db.query(CatalogingCandidate.id)
-            .filter(
-                CatalogingCandidate.chapter_run_id == run.id,
-                CatalogingCandidate.status.notin_(["rejected", "applied"]),
-            )
-            .first()
-        )
+def _reconcile_coverage(
+    coverage: Any,
+    items: list[Any],
+    *,
+    db: Any,
+    project_id: str | None,
+) -> Any:
+    existing_worldbuilding, existing_characters = _load_existing_identities(
+        db,
+        project_id,
+    )
+    stable_anonymous = _anonymous_with_stable_cards(items)
+    unresolved = {
+        name
+        for name in coverage.declared_character_identities
         if (
-            existing is not None
-            and str(getattr(run, "status", "") or "") == "extracting"
-        ):
-            return
-        original_clear_candidates(db, run)
-
-    def try_create_candidates(
-        db: Any,
-        job: Any,
-        run: Any,
-        line: str,
-        sort_order: int,
-    ) -> list[dict[str, Any]]:
-        # The orchestrator resets its local counter after requesting a retry.
-        # Preserved cards still occupy sort positions, so continue after the
-        # actual staged row count instead of reusing zero-based positions.
-        existing_count = (
-            db.query(CatalogingCandidate)
-            .filter(CatalogingCandidate.chapter_run_id == run.id)
-            .count()
+            name not in existing_characters
+            and name not in stable_anonymous
+            and is_anonymous_character(name)
         )
-        return original_try_create_candidates(
-            db,
-            job,
-            run,
-            line,
-            max(int(sort_order or 0), int(existing_count or 0)),
-        )
+    }
+    if _reject_weak_anonymous_cards(items, unresolved):
+        assert _ORIGINAL_INSPECT is not None
+        coverage = _ORIGINAL_INSPECT(items, db=db, project_id=project_id)
+    sets = _candidate_sets(coverage)
+    worldbuilding = _reconcile_worldbuilding(coverage, existing_worldbuilding)
+    return _reconciled_coverage(
+        coverage,
+        sets=sets,
+        worldbuilding=worldbuilding,
+        unresolved=unresolved,
+    )
 
-    def has_meaningful_character_profile(payload: dict[str, Any]) -> bool:
-        if original_profile_check(payload):
-            return True
-        name = (
-            payload.get("name")
-            or payload.get("character_name")
-            or payload.get("target_name")
-        )
-        if _is_unresolved_character(name):
-            return False
-        # Character rows persist appearance and age, so a stable named newcomer
-        # with grounded visual/age evidence is not an identity-only blank card.
-        return any(
-            payload.get(key) not in (None, "", [], {})
-            for key in ("appearance", "age")
-        )
 
-    validation.inspect_candidate_coverage = inspect_candidate_coverage
-    validation.candidate_coverage_should_retry = candidate_coverage_should_retry
-    validation.candidate_coverage_error_message = candidate_coverage_error_message
-    validation.candidate_coverage_review_message = candidate_coverage_review_message
-    fact_store.clear_candidates_for_run = clear_candidates_for_run
-    candidate_store.try_create_candidates = try_create_candidates
-    granularity._has_meaningful_character_profile = has_meaningful_character_profile
+def _inspect_candidate_coverage(
+    candidates: Iterable[Any],
+    *,
+    db: Any = None,
+    project_id: str | None = None,
+) -> Any:
+    assert _ORIGINAL_INSPECT is not None
+    items = list(candidates)
+    coverage = _ORIGINAL_INSPECT(items, db=db, project_id=project_id)
+    return _reconcile_coverage(
+        coverage,
+        items,
+        db=db,
+        project_id=project_id,
+    )
 
+
+def _candidate_coverage_should_retry(coverage: Any) -> bool:
+    return bool(coverage.cli_parity_missing)
+
+
+def _diagnostic_details(coverage: Any) -> list[str]:
+    pairs = (
+        (
+            set(coverage.declared_character_identities)
+            - set(coverage.character_state_identities),
+            "缺少角色状态候选",
+        ),
+        (
+            set(coverage.declared_worldbuilding_identities)
+            - set(coverage.worldbuilding_candidate_identities),
+            "缺少世界观候选或既有设定关联",
+        ),
+        (
+            set(coverage.declared_relationship_identities)
+            - set(coverage.relationship_candidate_identities),
+            "缺少角色关系候选",
+        ),
+        (
+            set(coverage.declared_character_profile_identities)
+            - set(coverage.character_profile_candidate_identities),
+            "缺少角色资料候选",
+        ),
+        (
+            set(coverage.declared_character_identities)
+            - set(coverage.chapter_link_character_identities),
+            "缺少角色章节关联",
+        ),
+        (
+            set(coverage.declared_worldbuilding_identities)
+            - set(coverage.chapter_link_worldbuilding_identities),
+            "缺少世界观章节关联",
+        ),
+    )
+    return [
+        label + "：" + "、".join(sorted(values))
+        for values, label in pairs
+        if values
+    ]
+
+
+def _candidate_coverage_error_message(
+    coverage: Any,
+    *,
+    prefix: str = "候选覆盖不完整",
+) -> str:
+    assert _ORIGINAL_ERROR_MESSAGE is not None
+    base = _ORIGINAL_ERROR_MESSAGE(coverage, prefix=prefix)
+    details = _diagnostic_details(coverage)
+    return base if not details else base + "；" + "；".join(details)
+
+
+def _candidate_coverage_review_message(coverage: Any) -> str:
+    assert _ORIGINAL_REVIEW_MESSAGE is not None
+    return _ORIGINAL_REVIEW_MESSAGE(coverage)
+
+
+def _clear_candidates_for_run(db: Any, run: Any) -> None:
+    assert _ORIGINAL_CLEAR_CANDIDATES is not None
+    existing = (
+        db.query(CatalogingCandidate.id)
+        .filter(
+            CatalogingCandidate.chapter_run_id == run.id,
+            CatalogingCandidate.status.notin_(["rejected", "applied"]),
+        )
+        .first()
+    )
+    if existing is not None and str(getattr(run, "status", "") or "") == "extracting":
+        return
+    _ORIGINAL_CLEAR_CANDIDATES(db, run)
+
+
+def _reject_created_anonymous_cards(
+    results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    for result in results:
+        candidate = result.get("candidate")
+        if candidate is None:
+            continue
+        if candidate_type(candidate) not in {"character_create", "character_update"}:
+            continue
+        payload = candidate_payload(candidate)
+        name = candidate_character_name(candidate)
+        if not is_anonymous_character(name) or has_stable_profile_evidence(payload):
+            continue
+        candidate.status = "rejected"
+        candidate.error = "身份未确认且缺少稳定档案，已保留为章节线索"
+        result.pop("candidate", None)
+        result["skipped"] = True
+        result["reason"] = candidate.error
+    return results
+
+
+def _try_create_candidates(
+    db: Any,
+    job: Any,
+    run: Any,
+    line: str,
+    sort_order: int,
+) -> list[dict[str, Any]]:
+    assert _ORIGINAL_TRY_CREATE_CANDIDATES is not None
+    existing_count = (
+        db.query(CatalogingCandidate)
+        .filter(CatalogingCandidate.chapter_run_id == run.id)
+        .count()
+    )
+    results = _ORIGINAL_TRY_CREATE_CANDIDATES(
+        db,
+        job,
+        run,
+        line,
+        max(int(sort_order or 0), int(existing_count or 0)),
+    )
+    return _reject_created_anonymous_cards(results)
+
+
+def _has_meaningful_character_profile(payload: dict[str, Any]) -> bool:
+    assert _ORIGINAL_PROFILE_CHECK is not None
+    if _ORIGINAL_PROFILE_CHECK(payload):
+        return True
+    name = (
+        payload.get("name")
+        or payload.get("character_name")
+        or payload.get("target_name")
+    )
+    if is_anonymous_character(name):
+        return False
+    return any(
+        payload.get(key) not in (None, "", [], {})
+        for key in ("appearance", "age")
+    )
+
+
+def _candidate_rules_with_repair() -> str:
+    assert _ORIGINAL_CANDIDATE_RULES is not None
+    value = _ORIGINAL_CANDIDATE_RULES()
+    return value if _REPAIR_PROMPT in value else value + "\n\n" + _REPAIR_PROMPT
+
+
+def _install_prompt_rules(staged_prompts: Any, cataloging_source: Any) -> None:
+    global _ORIGINAL_CANDIDATE_RULES
+    _ORIGINAL_CANDIDATE_RULES = cataloging_source.get_cataloging_candidate_rules
+    cataloging_source.get_cataloging_candidate_rules = _candidate_rules_with_repair
     if _REPAIR_PROMPT not in staged_prompts.CATALOGING_RESOLUTION_SYSTEM_PROMPT:
         staged_prompts.CATALOGING_RESOLUTION_SYSTEM_PROMPT += "\n\n" + _REPAIR_PROMPT
     if _REPAIR_PROMPT not in staged_prompts.CATALOGING_MERGED_SYSTEM_PROMPT:
         staged_prompts.CATALOGING_MERGED_SYSTEM_PROMPT += "\n\n" + _REPAIR_PROMPT
 
-    if cataloging_source is not None and original_candidate_rules is not None:
 
-        def get_cataloging_candidate_rules() -> str:
-            value = original_candidate_rules()
-            return value if _REPAIR_PROMPT in value else value + "\n\n" + _REPAIR_PROMPT
+def _install_validation_rules(
+    validation: Any,
+    candidate_store: Any,
+    granularity: Any,
+) -> None:
+    validation.inspect_candidate_coverage = _inspect_candidate_coverage
+    validation.candidate_coverage_should_retry = _candidate_coverage_should_retry
+    validation.candidate_coverage_error_message = _candidate_coverage_error_message
+    validation.candidate_coverage_review_message = _candidate_coverage_review_message
+    candidate_store.inspect_candidate_coverage = _inspect_candidate_coverage
+    granularity._has_meaningful_character_profile = _has_meaningful_character_profile
 
-        cataloging_source.get_cataloging_candidate_rules = get_cataloging_candidate_rules
+
+def install_cataloging_runtime_repairs() -> None:
+    """Install the shared repair policy exactly once."""
+
+    global _INSTALLED
+    global _ORIGINAL_CLEAR_CANDIDATES
+    global _ORIGINAL_ERROR_MESSAGE
+    global _ORIGINAL_INSPECT
+    global _ORIGINAL_PROFILE_CHECK
+    global _ORIGINAL_REVIEW_MESSAGE
+    global _ORIGINAL_TRY_CREATE_CANDIDATES
+
+    if _INSTALLED:
+        return
+
+    granularity = import_module("app.services.story_granularity")
+    candidate_store = import_module("app.services.cataloging.candidate_store")
+    validation = import_module("app.services.cataloging.candidate_validation")
+    fact_store = import_module("app.services.cataloging.fact_store")
+    staged_prompts = import_module("app.services.cataloging.staged_prompts")
+    cataloging_source = import_module("app.prompts.cataloging_source")
+
+    _ORIGINAL_INSPECT = validation.inspect_candidate_coverage
+    _ORIGINAL_ERROR_MESSAGE = validation.candidate_coverage_error_message
+    _ORIGINAL_REVIEW_MESSAGE = validation.candidate_coverage_review_message
+    _ORIGINAL_CLEAR_CANDIDATES = fact_store.clear_candidates_for_run
+    _ORIGINAL_TRY_CREATE_CANDIDATES = candidate_store.try_create_candidates
+    _ORIGINAL_PROFILE_CHECK = granularity._has_meaningful_character_profile
+
+    _install_validation_rules(validation, candidate_store, granularity)
+    fact_store.clear_candidates_for_run = _clear_candidates_for_run
+    candidate_store.try_create_candidates = _try_create_candidates
+    _install_prompt_rules(staged_prompts, cataloging_source)
+    _INSTALLED = True

--- a/backend/app/services/cataloging/runtime_repair.py
+++ b/backend/app/services/cataloging/runtime_repair.py
@@ -1,0 +1,476 @@
+"""Runtime repairs for cataloging candidate completeness.
+
+The cataloging pipeline streams useful candidates before it knows whether the
+whole chapter satisfies the coverage contract. Providers often omit one or
+two trailing cards, vary an identity label, or stop after a long response. A
+full retry used to delete the valid cards and could fail again on a different
+item. This module installs one shared repair policy for internal API, local
+CLI, PC Gateway, and Android-triggered cataloging:
+
+* keep valid staged candidates while a repair turn is running;
+* retry every remaining hard coverage gap with exact missing identities;
+* canonicalize harmless worldbuilding title decorations;
+* accept existing unchanged settings when they are linked to the chapter;
+* keep anonymous/unknown figures chapter-local instead of forcing blank cards;
+* move surplus candidate identities to review warnings instead of blocking.
+
+The hooks are installed from ``cataloging.__init__`` before the orchestrator
+imports these functions. Keeping the policy in one module makes the behavior
+identical for all front ends while avoiding a second mobile-only validator.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import Any, Iterable
+
+from ...database.models import CatalogingCandidate, Character, WorldbuildingEntry
+from .. import story_granularity as granularity
+from . import candidate_store
+from . import candidate_validation as validation
+from . import fact_store, staged_prompts
+
+_INSTALLED = False
+
+_REPAIR_PROMPT = r"""
+【候选缺项自动修复】
+- 当用户消息包含“上一轮校验未通过”时，这是增量修复回合。系统会保留上一轮已经通过的候选；只补充错误信息明确指出的缺失身份，或修正身份不一致的候选，不要为了重试删除、缩减或改写已有正确卡片。
+- 结束前逐项核对 coverage_manifest 与候选：characters 对应 character_state_update；worldbuilding 中真正新增、变化、确认、受损、受限或被使用的设定对应 worldbuilding_create/update/timeline；character_profiles 对应 character_create/update；relationships 对应 character_relationship；每个角色和设定都有 chapter_link。
+- 已存在且本章只是引用、没有新增或变化的世界观，不要虚构 update；保留其清单身份并输出同标题 chapter_link 即可。
+- coverage_manifest 中的名称必须与候选 name/title 完全一致。说明性后缀放进 content/description，不要把“系统”改写成“系统（无界面·无沟通·自行探索型）”之类的新标题。
+- “神秘人影、陌生声音、黑影、蒙面人”等尚无稳定身份的描述，只作为本章出场线索和 chapter_link/摘要信息；除非正文已提供可持续使用的稳定档案，否则不要放入 character_profiles，也不要创建空白永久角色卡。
+- 如果输出很长，优先保证清单中每个身份都有对应候选，再补充非必需时间线与说明；不得在已经声明完整清单后提前结束。
+""".strip()
+
+_ANONYMOUS_CHARACTER_EXACT = {
+    "人影",
+    "身影",
+    "黑影",
+    "神秘人影",
+    "神秘身影",
+    "陌生人",
+    "陌生人影",
+    "陌生声音",
+    "神秘声音",
+    "未知声音",
+    "无名者",
+    "来人",
+    "访客",
+    "袭击者",
+    "追兵",
+    "蒙面人",
+    "黑衣人",
+    "斗篷人",
+}
+_ANONYMOUS_CHARACTER_PATTERN = re.compile(
+    r"^(?:神秘|陌生|未知|不明|模糊|黑衣|蒙面|斗篷|无名|某)"
+    r"(?:人|人影|身影|声音|女子|男子|老人|少年|少女|修士|来客|存在|角色|者)?"
+    r"(?:[甲乙丙丁]|\d+)?$"
+)
+_TRAILING_DESCRIPTOR = re.compile(
+    r"(?:[（(【\[][^（）()【】\[\]]{2,80}[）)】\]])+$"
+)
+
+
+def _identity(value: Any) -> str:
+    return re.sub(r"\s+", "", str(value or "").strip()).casefold()
+
+
+def _worldbuilding_base(value: Any) -> str:
+    raw = _identity(value)
+    if not raw:
+        return ""
+    base = _TRAILING_DESCRIPTOR.sub("", raw).strip("-—:：·")
+    return base or raw
+
+
+def _is_unresolved_character(value: Any) -> bool:
+    raw = _identity(value)
+    if not raw:
+        return False
+    return raw in _ANONYMOUS_CHARACTER_EXACT or bool(
+        _ANONYMOUS_CHARACTER_PATTERN.fullmatch(raw)
+    )
+
+
+def _split_diagnostic_identities(item: str, prefix: str) -> list[str] | None:
+    if not item.startswith(prefix):
+        return None
+    _, separator, detail = item.partition(": ")
+    if not separator:
+        return []
+    return [part.strip() for part in detail.split("、") if part.strip()]
+
+
+def _filter_diagnostic_identities(
+    items: Iterable[str],
+    *,
+    prefixes: tuple[str, ...],
+    excluded: set[str],
+) -> tuple[str, ...]:
+    result: list[str] = []
+    for item in items:
+        replaced = False
+        for prefix in prefixes:
+            identities = _split_diagnostic_identities(item, prefix)
+            if identities is None:
+                continue
+            kept = [name for name in identities if _identity(name) not in excluded]
+            if kept:
+                result.append(f"{prefix}: " + "、".join(kept))
+            replaced = True
+            break
+        if not replaced:
+            result.append(item)
+    return tuple(result)
+
+
+def _worldbuilding_alias_map(
+    values: Iterable[str],
+    declared: set[str],
+) -> dict[str, str]:
+    values = {item for item in values if item}
+    by_base: dict[str, set[str]] = {}
+    for value in values:
+        by_base.setdefault(_worldbuilding_base(value), set()).add(value)
+
+    result = {value: value for value in values}
+    for base, variants in by_base.items():
+        declared_variants = variants & declared
+        if len(declared_variants) == 1:
+            canonical = next(iter(declared_variants))
+        elif base in variants:
+            canonical = base
+        elif len(variants) == 1:
+            canonical = next(iter(variants))
+        else:
+            # Ambiguous decorated titles remain separate and require review.
+            continue
+        for variant in variants:
+            result[variant] = canonical
+    return result
+
+
+def _canonicalize(values: Iterable[str], aliases: dict[str, str]) -> set[str]:
+    return {aliases.get(value, value) for value in values if value}
+
+
+def _diagnostic_details(coverage: granularity.CandidateCoverage) -> list[str]:
+    details: list[str] = []
+    missing_states = set(coverage.declared_character_identities) - set(
+        coverage.character_state_identities
+    )
+    missing_worldbuilding = set(coverage.declared_worldbuilding_identities) - set(
+        coverage.worldbuilding_candidate_identities
+    )
+    missing_relationships = set(coverage.declared_relationship_identities) - set(
+        coverage.relationship_candidate_identities
+    )
+    missing_profiles = set(coverage.declared_character_profile_identities) - set(
+        coverage.character_profile_candidate_identities
+    )
+    missing_character_links = set(coverage.declared_character_identities) - set(
+        coverage.chapter_link_character_identities
+    )
+    missing_worldbuilding_links = set(coverage.declared_worldbuilding_identities) - set(
+        coverage.chapter_link_worldbuilding_identities
+    )
+    if missing_states:
+        details.append("缺少角色状态候选：" + "、".join(sorted(missing_states)))
+    if missing_worldbuilding:
+        details.append(
+            "缺少世界观候选或既有设定关联："
+            + "、".join(sorted(missing_worldbuilding))
+        )
+    if missing_relationships:
+        details.append("缺少角色关系候选：" + "、".join(sorted(missing_relationships)))
+    if missing_profiles:
+        details.append("缺少角色资料候选：" + "、".join(sorted(missing_profiles)))
+    if missing_character_links:
+        details.append("缺少角色章节关联：" + "、".join(sorted(missing_character_links)))
+    if missing_worldbuilding_links:
+        details.append(
+            "缺少世界观章节关联：" + "、".join(sorted(missing_worldbuilding_links))
+        )
+    return details
+
+
+def install_cataloging_runtime_repairs() -> None:
+    """Install one idempotent completeness/repair policy for cataloging."""
+
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+
+    original_inspect = validation.inspect_candidate_coverage
+    original_error_message = validation.candidate_coverage_error_message
+    original_review_message = validation.candidate_coverage_review_message
+    original_clear_candidates = fact_store.clear_candidates_for_run
+    original_try_create_candidates = candidate_store.try_create_candidates
+    original_profile_check = granularity._has_meaningful_character_profile
+    original_candidate_rules = None
+
+    try:
+        from ...prompts import cataloging_source
+
+        original_candidate_rules = cataloging_source.get_cataloging_candidate_rules
+    except Exception:  # pragma: no cover - prompt module is always present in production
+        cataloging_source = None
+
+    def inspect_candidate_coverage(
+        candidates: Iterable[Any],
+        *,
+        db: Any = None,
+        project_id: str | None = None,
+    ) -> granularity.CandidateCoverage:
+        items = list(candidates)
+        coverage = original_inspect(items, db=db, project_id=project_id)
+
+        declared_characters = set(coverage.declared_character_identities)
+        character_states = set(coverage.character_state_identities)
+        declared_profiles = set(coverage.declared_character_profile_identities)
+        profile_candidates = set(coverage.character_profile_candidate_identities)
+        declared_relationships = set(coverage.declared_relationship_identities)
+        relationship_candidates = set(coverage.relationship_candidate_identities)
+        character_links = set(coverage.chapter_link_character_identities)
+
+        declared_worldbuilding = set(coverage.declared_worldbuilding_identities)
+        worldbuilding_candidates = set(coverage.worldbuilding_candidate_identities)
+        worldbuilding_links = set(coverage.chapter_link_worldbuilding_identities)
+        existing_worldbuilding: set[str] = set()
+        existing_characters: set[str] = set()
+        if db is not None and project_id:
+            existing_worldbuilding = {
+                _identity(row.title)
+                for row in db.query(WorldbuildingEntry)
+                .filter(WorldbuildingEntry.project_id == project_id)
+                .all()
+                if _identity(row.title)
+            }
+            existing_characters = {
+                _identity(row.name)
+                for row in db.query(Character)
+                .filter(Character.project_id == project_id)
+                .all()
+                if _identity(row.name)
+            }
+
+        world_values = (
+            declared_worldbuilding
+            | worldbuilding_candidates
+            | worldbuilding_links
+            | existing_worldbuilding
+        )
+        world_aliases = _worldbuilding_alias_map(
+            world_values,
+            declared_worldbuilding,
+        )
+        declared_worldbuilding = _canonicalize(
+            declared_worldbuilding,
+            world_aliases,
+        )
+        worldbuilding_candidates = _canonicalize(
+            worldbuilding_candidates,
+            world_aliases,
+        )
+        worldbuilding_links = _canonicalize(worldbuilding_links, world_aliases)
+        existing_worldbuilding = _canonicalize(
+            existing_worldbuilding,
+            world_aliases,
+        )
+
+        # A pre-existing setting that is merely referenced does not need a fake
+        # update card. Its same-title chapter_link is the persistence action.
+        linked_existing = (
+            declared_worldbuilding & worldbuilding_links & existing_worldbuilding
+        )
+        covered_worldbuilding = worldbuilding_candidates | linked_existing
+
+        extra_states = character_states - declared_characters
+        extra_profiles = profile_candidates - declared_profiles
+        extra_relationships = relationship_candidates - declared_relationships
+        extra_worldbuilding = worldbuilding_candidates - declared_worldbuilding
+        extra_character_links = character_links - declared_characters
+        extra_worldbuilding_links = worldbuilding_links - declared_worldbuilding
+
+        unresolved_characters = {
+            identity
+            for identity in declared_characters
+            if identity not in existing_characters and _is_unresolved_character(identity)
+        }
+        declared_profiles -= unresolved_characters
+
+        review_warnings = list(coverage.review_warnings)
+        if extra_states:
+            review_warnings.append(
+                "角色状态候选未写入 coverage_manifest.characters："
+                + "、".join(sorted(extra_states))
+            )
+        if extra_profiles:
+            review_warnings.append(
+                "角色资料候选未写入 coverage_manifest.character_profiles："
+                + "、".join(sorted(extra_profiles))
+            )
+        if extra_relationships:
+            review_warnings.append(
+                "角色关系候选未写入 coverage_manifest.relationships："
+                + "、".join(sorted(extra_relationships))
+            )
+        if extra_worldbuilding:
+            review_warnings.append(
+                "世界观候选未写入 coverage_manifest.worldbuilding："
+                + "、".join(sorted(extra_worldbuilding))
+            )
+        if extra_character_links:
+            review_warnings.append(
+                "章节关联包含清单外角色：" + "、".join(sorted(extra_character_links))
+            )
+        if extra_worldbuilding_links:
+            review_warnings.append(
+                "章节关联包含清单外世界观："
+                + "、".join(sorted(extra_worldbuilding_links))
+            )
+        if unresolved_characters:
+            review_warnings.append(
+                "身份未确认角色按章节线索保留，不强制建立永久角色卡："
+                + "、".join(sorted(unresolved_characters))
+            )
+
+        persistence_missing = _filter_diagnostic_identities(
+            coverage.persistence_missing,
+            prefixes=(
+                "character_create/update for new declared characters",
+                "relationship endpoints without character profiles",
+            ),
+            excluded=unresolved_characters,
+        )
+
+        # Surplus cards are useful data and should be reviewed, not treated as
+        # data loss. Contract counts below only include declared identities.
+        character_states &= declared_characters
+        profile_candidates &= declared_profiles
+        relationship_candidates &= declared_relationships
+        character_links &= declared_characters
+        covered_worldbuilding &= declared_worldbuilding
+        worldbuilding_links &= declared_worldbuilding
+
+        return replace(
+            coverage,
+            declared_character_profile_count=len(declared_profiles),
+            character_state_count=len(character_states),
+            worldbuilding_candidate_count=len(covered_worldbuilding),
+            relationship_candidate_count=len(relationship_candidates),
+            character_profile_candidate_count=len(profile_candidates),
+            declared_worldbuilding_count=len(declared_worldbuilding),
+            declared_character_profile_identities=tuple(sorted(declared_profiles)),
+            character_state_identities=tuple(sorted(character_states)),
+            worldbuilding_candidate_identities=tuple(sorted(covered_worldbuilding)),
+            relationship_candidate_identities=tuple(sorted(relationship_candidates)),
+            character_profile_candidate_identities=tuple(sorted(profile_candidates)),
+            declared_worldbuilding_identities=tuple(sorted(declared_worldbuilding)),
+            chapter_link_character_identities=tuple(sorted(character_links)),
+            chapter_link_worldbuilding_identities=tuple(sorted(worldbuilding_links)),
+            persistence_missing=persistence_missing,
+            review_warnings=tuple(dict.fromkeys(review_warnings)),
+        )
+
+    def candidate_coverage_should_retry(
+        coverage: granularity.CandidateCoverage,
+    ) -> bool:
+        # After deterministic reconciliation, every remaining hard gap is a
+        # real missing card and should receive an incremental model repair turn.
+        return bool(coverage.cli_parity_missing)
+
+    def candidate_coverage_error_message(
+        coverage: granularity.CandidateCoverage,
+        *,
+        prefix: str = "候选覆盖不完整",
+    ) -> str:
+        base = original_error_message(coverage, prefix=prefix)
+        details = _diagnostic_details(coverage)
+        return base if not details else base + "；" + "；".join(details)
+
+    def candidate_coverage_review_message(
+        coverage: granularity.CandidateCoverage,
+    ) -> str:
+        return original_review_message(coverage)
+
+    def clear_candidates_for_run(db: Any, run: Any) -> None:
+        # The first pass has no cards. Any later call while extracting is a
+        # repair/retry pass, so retain its valid staged cards and merge fixes.
+        existing = (
+            db.query(CatalogingCandidate.id)
+            .filter(
+                CatalogingCandidate.chapter_run_id == run.id,
+                CatalogingCandidate.status.notin_(["rejected", "applied"]),
+            )
+            .first()
+        )
+        if (
+            existing is not None
+            and str(getattr(run, "status", "") or "") == "extracting"
+        ):
+            return
+        original_clear_candidates(db, run)
+
+    def try_create_candidates(
+        db: Any,
+        job: Any,
+        run: Any,
+        line: str,
+        sort_order: int,
+    ) -> list[dict[str, Any]]:
+        # The orchestrator resets its local counter after requesting a retry.
+        # Preserved cards still occupy sort positions, so continue after the
+        # actual staged row count instead of reusing zero-based positions.
+        existing_count = (
+            db.query(CatalogingCandidate)
+            .filter(CatalogingCandidate.chapter_run_id == run.id)
+            .count()
+        )
+        return original_try_create_candidates(
+            db,
+            job,
+            run,
+            line,
+            max(int(sort_order or 0), int(existing_count or 0)),
+        )
+
+    def has_meaningful_character_profile(payload: dict[str, Any]) -> bool:
+        if original_profile_check(payload):
+            return True
+        name = (
+            payload.get("name")
+            or payload.get("character_name")
+            or payload.get("target_name")
+        )
+        if _is_unresolved_character(name):
+            return False
+        # Character rows persist appearance and age, so a stable named newcomer
+        # with grounded visual/age evidence is not an identity-only blank card.
+        return any(
+            payload.get(key) not in (None, "", [], {})
+            for key in ("appearance", "age")
+        )
+
+    validation.inspect_candidate_coverage = inspect_candidate_coverage
+    validation.candidate_coverage_should_retry = candidate_coverage_should_retry
+    validation.candidate_coverage_error_message = candidate_coverage_error_message
+    validation.candidate_coverage_review_message = candidate_coverage_review_message
+    fact_store.clear_candidates_for_run = clear_candidates_for_run
+    candidate_store.try_create_candidates = try_create_candidates
+    granularity._has_meaningful_character_profile = has_meaningful_character_profile
+
+    if _REPAIR_PROMPT not in staged_prompts.CATALOGING_RESOLUTION_SYSTEM_PROMPT:
+        staged_prompts.CATALOGING_RESOLUTION_SYSTEM_PROMPT += "\n\n" + _REPAIR_PROMPT
+    if _REPAIR_PROMPT not in staged_prompts.CATALOGING_MERGED_SYSTEM_PROMPT:
+        staged_prompts.CATALOGING_MERGED_SYSTEM_PROMPT += "\n\n" + _REPAIR_PROMPT
+
+    if cataloging_source is not None and original_candidate_rules is not None:
+
+        def get_cataloging_candidate_rules() -> str:
+            value = original_candidate_rules()
+            return value if _REPAIR_PROMPT in value else value + "\n\n" + _REPAIR_PROMPT
+
+        cataloging_source.get_cataloging_candidate_rules = get_cataloging_candidate_rules

--- a/backend/prompt_specs/continuity/cataloging-merged.md
+++ b/backend/prompt_specs/continuity/cataloging-merged.md
@@ -1,6 +1,6 @@
 ---
 id: continuity.cataloging.merged
-version: 3.1.6
+version: 3.1.7
 scope: continuity
 visibility: both
 inputs: []
@@ -16,6 +16,8 @@ budget:
 golden_cases:
   - name: required-granularity
     required_text: ["chapter_summary", "chapter_outline", "首个响应对象", "coverage_manifest", "relationships", "character_profiles", "character_state_update", "node_type=\"section\"", "chapter_link", "JSONL"]
+  - name: incremental-repair
+    required_text: ["增量修复回合", "保留上一轮", "缺失身份", "既有设定", "身份未确认"]
   - name: narrative-ledger
     required_text: ["narrative_state", "narrative_review", "resolves_item_id", "不得按标题猜测关闭"]
 ---
@@ -29,7 +31,7 @@ golden_cases:
 - 除这个首个必填骨架对象外，禁止把 character_state_updates、worldbuilding_entries、outline_creates、chapter_links 等打包进总对象；其他每张候选必须独占一行并带标准 type。
 - 没有角色、新设定、关系或角色档案变化时，coverage_manifest 对应项必须显式写 []；空数组是合法结果，禁止为满足格式虚构候选。
 - chapter_summary 必须包含非空 summary_text，用一段话概括本章已经发生的主要事件；同时显式包含完整 narrative_state，没有发现时各数组也写 []，并提供 narrative_review，不能用字段缺失表示“没有问题”。
-- chapter_summary 必须包含 `coverage_manifest`：`scene_count` 是本章独立场景数，`characters` 是本章全部出场或被提及且影响连续性的角色名，`worldbuilding` 是本章新增、变化或被关键引用的设定标题，`relationships` 是本章明确确认、首次出现或改变且影响连续性的角色关系对象（source_name、target_name、relationship_type），`character_profiles` 是本章新建角色或稳定档案有新增信息的角色名；即使没有也必须写 1、[]、[]、[]、[]，不得省略。该清单是验收合同，不是备注。
+- chapter_summary 必须包含 `coverage_manifest`：`scene_count` 是本章独立场景数，`characters` 是本章全部出场或被提及且影响连续性的稳定角色名，`worldbuilding` 是本章新增、变化或被关键引用的设定标题，`relationships` 是本章明确确认、首次出现或改变且影响连续性的角色关系对象（source_name、target_name、relationship_type），`character_profiles` 是本章新建角色或稳定档案有新增信息的角色名；即使没有也必须写 1、[]、[]、[]、[]，不得省略。该清单是验收合同，不是备注。
 - 多场景章节额外输出 2-6 条 node_type="section" 的 outline_create，以 parent_title 绑定章节点。
 - 模型不得生成或猜测数据库 parent_id、target_id 等 UUID。新建 section 只填写 parent_title，真实父级 ID 由司命解析。
 - 不输出 chapter_overview、character_fact 等旧两阶段中间事实。
@@ -38,11 +40,18 @@ golden_cases:
 - 同一批候选中的角色身份必须使用角色卡的稳定主名；别名只写进 aliases。不得在清单或候选名中使用“特昂糖（陆糖）”“爷爷（陆家老爷子）”这类组合展示名，也不得在主名、昵称、称谓之间交替指代同一角色。
 - 每个出场角色输出 character_state_update，覆盖 appearance、age、life_status、current_location、realm_or_level、physical_state、mental_state、current_goal、active_conflict、abilities_state、items_or_assets。
 - 新角色用 character_create；稳定档案出现新信息时用 character_update，并合并完整 background、aliases、profile 和 custom_system_prompt。profile 覆盖 core_motivation、inner_lack、core_belief、public_persona、hidden_persona、reveal_chapter、moral_taboo、voice、action_habit、trauma_trigger；只写有正文或旧档案依据的内容，不编造。
+- “神秘人影、陌生声音、黑影、蒙面人”等身份未确认的描述，只作为本章角色线索写入摘要、场景和 chapter_link；除非正文已经提供可持续使用的稳定档案，否则不要放入 character_profiles，也不要创建空白永久角色卡。
 - character_create/update 的 role_type 只能是 protagonist、supporting、antagonist、mentor、other 之一；“穿越者”“陆家三岁孙女”等身份描述应写入 background/age，禁止与“主角”一起拼入 role_type。
-- 新设定或变化使用 worldbuilding_create、worldbuilding_update、worldbuilding_timeline；维度仅用 geography、history、factions、power_system、races、culture。
-- `coverage_manifest.characters` 中每个角色都必须有同名独立 character_state_update；`coverage_manifest.worldbuilding` 中每项都必须有同标题独立 worldbuilding_create/update/timeline；`coverage_manifest.character_profiles` 中每个角色必须有同名 character_create/update；`coverage_manifest.relationships` 中每个关系必须有同端点、同类型的 character_relationship。系统按身份逐项核对，重复卡不能凑数，数量或身份不足时本章不会通过验收。
+- 新设定或变化使用 worldbuilding_create、worldbuilding_update、worldbuilding_timeline；维度仅用 geography、history、factions、power_system、races、culture。已有设定若本章只是关键引用且没有变化，不要虚构 update，同标题 chapter_link 即可。
+- `coverage_manifest.characters` 中每个稳定角色都必须有同名独立 character_state_update；`coverage_manifest.worldbuilding` 中新增、变化、确认、受损、受限或被使用的设定必须有同标题 worldbuilding_create/update/timeline，既有且未变化的引用必须有同标题 chapter_link；`coverage_manifest.character_profiles` 中每个角色必须有同名 character_create/update；`coverage_manifest.relationships` 中每个关系必须有同端点、同类型的 character_relationship。系统按身份逐项核对，重复卡不能凑数，数量或身份不足时本章不会通过验收。
+- 世界观清单、候选和 chapter_link 必须使用完全相同的稳定标题。不要把“系统”改写成“系统（无界面·无沟通·自行探索型）”；说明性后缀写入 content/description。
 - 亲属、师徒、盟友、敌对、主从、利益合作、情感关系等，只要正文明确且影响后续写作，就必须进入 relationships 和 character_relationship；双方都必须列入 characters，并已有角色档案或先输出 character_create/update。地点、功法、组织、事件不能作为角色关系端点。
 - 使用 chapter_link 记录角色、设定、大纲、地点、物品、事件、重要性和出场顺序；至少为清单中的每个角色和每项世界观各输出一条 chapter_link。角色关联使用 `character_names: [角色名]`，设定关联使用 `worldbuilding_titles: [设定标题]`，并填写 description，避免把章节关联误写成角色关系卡。
+
+【候选缺项自动修复】
+- 当用户消息包含“上一轮校验未通过”时，这是增量修复回合。系统会保留上一轮已经通过的候选；只补充错误信息明确指出的缺失身份，或修正身份不一致的候选，不要删除、缩减或改写已有正确卡片。
+- 结束前逐项核对 coverage_manifest 与候选的名称和数量。错误信息给出“缺少角色状态候选、缺少世界观候选、缺少角色资料候选、缺少关系候选、缺少章节关联”时，必须逐个补齐，不要只重新输出摘要。
+- 如果输出很长，优先保证清单中每个身份都有对应候选，再补充非必需时间线与说明；不得在已经声明完整清单后提前结束。
 
 【section 场景】
 每个独立场景都必须有一条 section 候选，并包含 scene_number、purpose、location、timeline、pov_character、characters、entry_state、exit_state、emotional_residue、unresolved_actions；没有内容的字段用空数组或明确的“未发生变化”，不得省略整张场景卡。

--- a/backend/prompt_specs/continuity/cataloging-merged.md
+++ b/backend/prompt_specs/continuity/cataloging-merged.md
@@ -42,7 +42,7 @@ golden_cases:
 - 新角色用 character_create；稳定档案出现新信息时用 character_update，并合并完整 background、aliases、profile 和 custom_system_prompt。profile 覆盖 core_motivation、inner_lack、core_belief、public_persona、hidden_persona、reveal_chapter、moral_taboo、voice、action_habit、trauma_trigger；只写有正文或旧档案依据的内容，不编造。
 - “神秘人影、陌生声音、黑影、蒙面人”等身份未确认的描述，只作为本章角色线索写入摘要、场景和 chapter_link；除非正文已经提供可持续使用的稳定档案，否则不要放入 character_profiles，也不要创建空白永久角色卡。
 - character_create/update 的 role_type 只能是 protagonist、supporting、antagonist、mentor、other 之一；“穿越者”“陆家三岁孙女”等身份描述应写入 background/age，禁止与“主角”一起拼入 role_type。
-- 新设定或变化使用 worldbuilding_create、worldbuilding_update、worldbuilding_timeline；维度仅用 geography、history、factions、power_system、races、culture。已有设定若本章只是关键引用且没有变化，不要虚构 update，同标题 chapter_link 即可。
+- 新设定或变化使用 worldbuilding_create、worldbuilding_update、worldbuilding_timeline；维度仅用 geography、history、factions、power_system、races、culture。既有设定若本章只是关键引用且没有变化，不要虚构 update，同标题 chapter_link 即可。
 - `coverage_manifest.characters` 中每个稳定角色都必须有同名独立 character_state_update；`coverage_manifest.worldbuilding` 中新增、变化、确认、受损、受限或被使用的设定必须有同标题 worldbuilding_create/update/timeline，既有且未变化的引用必须有同标题 chapter_link；`coverage_manifest.character_profiles` 中每个角色必须有同名 character_create/update；`coverage_manifest.relationships` 中每个关系必须有同端点、同类型的 character_relationship。系统按身份逐项核对，重复卡不能凑数，数量或身份不足时本章不会通过验收。
 - 世界观清单、候选和 chapter_link 必须使用完全相同的稳定标题。不要把“系统”改写成“系统（无界面·无沟通·自行探索型）”；说明性后缀写入 content/description。
 - 亲属、师徒、盟友、敌对、主从、利益合作、情感关系等，只要正文明确且影响后续写作，就必须进入 relationships 和 character_relationship；双方都必须列入 characters，并已有角色档案或先输出 character_create/update。地点、功法、组织、事件不能作为角色关系端点。

--- a/backend/tests/test_cataloging_runtime_repair.py
+++ b/backend/tests/test_cataloging_runtime_repair.py
@@ -1,0 +1,496 @@
+"""Regression tests for cumulative cataloging completeness repair."""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database.models import (
+    Base,
+    CatalogingCandidate,
+    Chapter,
+    Project,
+    WorldbuildingEntry,
+)
+from app.services.cataloging.candidate_validation import (
+    candidate_coverage_error_message,
+    candidate_coverage_should_retry,
+    inspect_candidate_coverage,
+)
+from app.services.cataloging.fact_store import clear_candidates_for_run
+from app.services.cataloging.orchestrator import create_cataloging_job
+
+
+def database():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine)()
+
+
+def summary_payload(**manifest):
+    return {
+        "summary_text": "本章完成了可验证的连续性变化。",
+        "coverage_manifest": {
+            "scene_count": 1,
+            "characters": [],
+            "worldbuilding": [],
+            "relationships": [],
+            "character_profiles": [],
+            **manifest,
+        },
+        "narrative_state": {
+            "events": [{"title": "本章事件", "description": "事件已经发生"}],
+            "timeline_events": [],
+            "foreshadowing_planted": [],
+            "foreshadowing_resolved": [],
+            "storyline_progress": [],
+            "new_storylines": [],
+            "reader_known_facts": [],
+            "character_known_facts": [],
+            "unresolved_actions": [],
+        },
+        "narrative_review": {"source": "provided", "outcome": "assessed"},
+    }
+
+
+def candidate(db, job, run, chapter, item_type, payload, sort_order=0):
+    row = CatalogingCandidate(
+        job_id=job.id,
+        chapter_run_id=run.id,
+        project_id=chapter.project_id,
+        chapter_id=chapter.id,
+        item_type=item_type,
+        raw_payload=json.dumps(payload, ensure_ascii=False),
+        sort_order=sort_order,
+        status="pending",
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def base_rows(db, job, run, chapter, **manifest):
+    return [
+        candidate(
+            db,
+            job,
+            run,
+            chapter,
+            "chapter_summary",
+            summary_payload(**manifest),
+        ),
+        candidate(
+            db,
+            job,
+            run,
+            chapter,
+            "outline_create",
+            {
+                "node_type": "chapter",
+                "title": chapter.title,
+                "summary": "本章结构摘要。",
+            },
+            1,
+        ),
+    ]
+
+
+def test_decorated_worldbuilding_title_matches_manifest_identity():
+    engine, db = database()
+    try:
+        project = Project(id="project-1", title="标题归一化")
+        chapter = Chapter(
+            id="chapter-1",
+            project_id=project.id,
+            title="第一章",
+            content="系统没有界面。",
+        )
+        db.add_all([project, chapter])
+        db.commit()
+        job = create_cataloging_job(
+            db,
+            project.id,
+            "auto",
+            "deepseek:test",
+            [chapter.id],
+        )
+        run = job.chapter_runs[0]
+        rows = base_rows(db, job, run, chapter, worldbuilding=["系统"])
+        rows.extend(
+            [
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "worldbuilding_create",
+                    {
+                        "title": "系统（无界面·无沟通·自行探索型）",
+                        "dimension": "power_system",
+                        "content": "系统没有界面和主动沟通能力。",
+                    },
+                    2,
+                ),
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "chapter_link",
+                    {
+                        "worldbuilding_titles": [
+                            "系统（无界面·无沟通·自行探索型）"
+                        ]
+                    },
+                    3,
+                ),
+            ]
+        )
+
+        coverage = inspect_candidate_coverage(
+            rows,
+            db=db,
+            project_id=project.id,
+        )
+
+        assert coverage.is_complete is True
+        assert coverage.declared_worldbuilding_identities == ("系统",)
+        assert coverage.worldbuilding_candidate_identities == ("系统",)
+        assert coverage.chapter_link_worldbuilding_identities == ("系统",)
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_existing_unchanged_worldbuilding_requires_link_not_fake_update():
+    engine, db = database()
+    try:
+        project = Project(id="project-1", title="既有设定引用")
+        chapter = Chapter(
+            id="chapter-1",
+            project_id=project.id,
+            title="第一章",
+            content="系统再次出现。",
+        )
+        entry = WorldbuildingEntry(
+            project_id=project.id,
+            dimension="power_system",
+            title="系统",
+            content="既有设定。",
+        )
+        db.add_all([project, chapter, entry])
+        db.commit()
+        job = create_cataloging_job(
+            db,
+            project.id,
+            "auto",
+            "deepseek:test",
+            [chapter.id],
+        )
+        run = job.chapter_runs[0]
+        rows = base_rows(db, job, run, chapter, worldbuilding=["系统"])
+        rows.append(
+            candidate(
+                db,
+                job,
+                run,
+                chapter,
+                "chapter_link",
+                {
+                    "worldbuilding_titles": ["系统"],
+                    "description": "本章关键引用",
+                },
+                2,
+            )
+        )
+
+        coverage = inspect_candidate_coverage(
+            rows,
+            db=db,
+            project_id=project.id,
+        )
+
+        assert coverage.is_complete is True
+        assert coverage.worldbuilding_candidate_count == 1
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_unresolved_figure_stays_chapter_local_without_blank_character_card():
+    engine, db = database()
+    try:
+        project = Project(id="project-1", title="匿名角色")
+        chapter = Chapter(
+            id="chapter-1",
+            project_id=project.id,
+            title="第一章",
+            content="神秘人影一闪而逝。",
+        )
+        db.add_all([project, chapter])
+        db.commit()
+        job = create_cataloging_job(
+            db,
+            project.id,
+            "auto",
+            "deepseek:test",
+            [chapter.id],
+        )
+        run = job.chapter_runs[0]
+        rows = base_rows(
+            db,
+            job,
+            run,
+            chapter,
+            characters=["神秘人影"],
+            character_profiles=["神秘人影"],
+        )
+        rows.extend(
+            [
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "character_state_update",
+                    {
+                        "name": "神秘人影",
+                        "life_status": "unknown",
+                        "current_location": "屋外",
+                        "physical_state": "一闪而逝",
+                    },
+                    2,
+                ),
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "chapter_link",
+                    {
+                        "character_names": ["神秘人影"],
+                        "description": "身份尚未确认",
+                    },
+                    3,
+                ),
+            ]
+        )
+
+        coverage = inspect_candidate_coverage(
+            rows,
+            db=db,
+            project_id=project.id,
+        )
+
+        assert coverage.is_complete is True
+        assert coverage.declared_character_profile_count == 0
+        assert any("身份未确认角色" in item for item in coverage.review_warnings)
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_stable_named_newcomer_with_appearance_is_persistable_profile():
+    engine, db = database()
+    try:
+        project = Project(id="project-1", title="最低角色资料")
+        chapter = Chapter(
+            id="chapter-1",
+            project_id=project.id,
+            title="第一章",
+            content="陈叙推门而入。",
+        )
+        db.add_all([project, chapter])
+        db.commit()
+        job = create_cataloging_job(
+            db,
+            project.id,
+            "auto",
+            "deepseek:test",
+            [chapter.id],
+        )
+        run = job.chapter_runs[0]
+        rows = base_rows(
+            db,
+            job,
+            run,
+            chapter,
+            characters=["陈叙"],
+            character_profiles=["陈叙"],
+        )
+        rows.extend(
+            [
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "character_create",
+                    {
+                        "name": "陈叙",
+                        "appearance": "身形清瘦，右眉有旧伤。",
+                        "age": "约二十岁",
+                    },
+                    2,
+                ),
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "character_state_update",
+                    {
+                        "name": "陈叙",
+                        "current_location": "门内",
+                        "life_status": "alive",
+                    },
+                    3,
+                ),
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "chapter_link",
+                    {"character_names": ["陈叙"]},
+                    4,
+                ),
+            ]
+        )
+
+        coverage = inspect_candidate_coverage(
+            rows,
+            db=db,
+            project_id=project.id,
+        )
+
+        assert coverage.is_complete is True
+        assert coverage.character_profile_candidate_identities == ("陈叙",)
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_real_missing_identity_is_retryable_and_reported_exactly():
+    engine, db = database()
+    try:
+        project = Project(id="project-1", title="定向补缺")
+        chapter = Chapter(
+            id="chapter-1",
+            project_id=project.id,
+            title="第一章",
+            content="系统启动归墟。",
+        )
+        db.add_all([project, chapter])
+        db.commit()
+        job = create_cataloging_job(
+            db,
+            project.id,
+            "auto",
+            "deepseek:test",
+            [chapter.id],
+        )
+        run = job.chapter_runs[0]
+        rows = base_rows(
+            db,
+            job,
+            run,
+            chapter,
+            worldbuilding=["系统", "归墟"],
+        )
+        rows.extend(
+            [
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "worldbuilding_create",
+                    {
+                        "title": "系统",
+                        "dimension": "power_system",
+                        "content": "负责引导探索。",
+                    },
+                    2,
+                ),
+                candidate(
+                    db,
+                    job,
+                    run,
+                    chapter,
+                    "chapter_link",
+                    {"worldbuilding_titles": ["系统", "归墟"]},
+                    3,
+                ),
+            ]
+        )
+
+        coverage = inspect_candidate_coverage(
+            rows,
+            db=db,
+            project_id=project.id,
+        )
+        message = candidate_coverage_error_message(coverage)
+
+        assert coverage.is_complete is False
+        assert candidate_coverage_should_retry(coverage) is True
+        assert "归墟" in message
+        assert "缺少世界观候选或既有设定关联" in message
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_retry_clear_keeps_valid_staged_candidates():
+    engine, db = database()
+    try:
+        project = Project(id="project-1", title="累计修复")
+        chapter = Chapter(
+            id="chapter-1",
+            project_id=project.id,
+            title="第一章",
+            content="正文。",
+        )
+        db.add_all([project, chapter])
+        db.commit()
+        job = create_cataloging_job(
+            db,
+            project.id,
+            "auto",
+            "deepseek:test",
+            [chapter.id],
+        )
+        run = job.chapter_runs[0]
+        candidate(
+            db,
+            job,
+            run,
+            chapter,
+            "chapter_summary",
+            summary_payload(),
+        )
+        run.status = "extracting"
+        db.flush()
+
+        clear_candidates_for_run(db, run)
+        db.flush()
+
+        assert (
+            db.query(CatalogingCandidate)
+            .filter(CatalogingCandidate.chapter_run_id == run.id)
+            .count()
+            == 1
+        )
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()


### PR DESCRIPTION
## 问题

当前建档在章节实体较多时，经常因少量候选缺失或身份标题漂移而暂停，例如：

- `worldbuilding candidates (5/7)`；
- `系统` 与 `系统（无界面·无沟通·自行探索型）` 被当成两个设定；
- `神秘人影` 等身份未确认描述被强制要求永久角色卡；
- 校验器知道缺什么，但只对摘要/大纲等结构错误重试；
- 真正重试时会清空上一轮有效候选，下一轮可能又漏掉别的卡。

## 修改

- 新增统一的候选完整性修复策略，供内部 API、本机 CLI、PC Gateway 与手机端触发的建档共用；
- 任意剩余硬性缺项都进入自动修复回合，并把精确缺失身份反馈给模型；
- 修复回合保留上一轮有效候选，后续响应与现有卡片累计合并，不再整章清空重跑；
- 重试后按数据库真实候选数续接 `sort_order`，避免保留候选后排序冲突；
- 对世界观标题的说明性括号后缀做安全归一化；
- 已存在且本章只是引用的世界观，以同标题 `chapter_link` 作为覆盖，不再强迫模型虚构 update；
- 清单外的额外候选改为人工核对警告，不再作为“数据缺失”阻断；
- `神秘人影/陌生声音/黑影/蒙面人` 等身份未确认对象保留为章节线索，不强制建立空白永久角色卡；
- 稳定命名的新角色若已有正文支持的外貌/年龄资料，可作为最低可落库角色资料；
- 更新融合建档提示词，明确增量补缺、稳定标题、既有设定引用和匿名角色边界。

## 回归测试

新增覆盖：

1. `系统` 与带说明性后缀标题的安全匹配；
2. 既有未变化设定只需章节关联；
3. 身份未确认角色不产生空白永久角色卡；
4. 稳定新角色的最低可落库资料；
5. 真正缺失身份可重试且错误中列出精确名称；
6. 重试时保留上一轮有效候选。

## 一致性

修复位于后端统一建档层。PC 与连接 Gateway 的手机端使用相同校验、自动补全、重试上限和最终写入结果，不在 Android 侧复制第二套缺项判断。