### PR TITLE
修复 Gitee 发行版总慢一个版本

### DIFF
--- a/.github/workflows/sync-gitee-after-release.yml
+++ b/.github/workflows/sync-gitee-after-release.yml
@@ -1,0 +1,79 @@
+name: Sync published release to Gitee
+
+on:
+  workflow_run:
+    workflows: ["Release Gate"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: sync-gitee-after-release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch-exact-release:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve the release tag published by Release Gate
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          remote_tags="$(git ls-remote --tags "https://github.com/${GITHUB_REPOSITORY}.git")"
+          tag="$(
+            awk -v sha="$HEAD_SHA" '
+              $1 == sha {
+                ref = $2
+                sub(/^refs\/tags\//, "", ref)
+                sub(/\^\{\}$/, "", ref)
+                if (ref ~ /^v[0-9]/) print ref
+              }
+            ' <<< "$remote_tags" | sort -V | tail -n 1
+          )"
+
+          if [[ -z "$tag" ]]; then
+            echo "Release Gate commit $HEAD_SHA has no v* tag; this was a normal main push."
+            echo "should_sync=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The publishing step is complete before workflow_run fires, but the
+          # release API can still be briefly eventually consistent.
+          for attempt in $(seq 1 12); do
+            if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "Resolved published release $tag at $HEAD_SHA"
+              echo "tag=$tag" >> "$GITHUB_OUTPUT"
+              echo "should_sync=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Release $tag is not visible yet ($attempt/12); waiting..."
+            sleep 5
+          done
+
+          echo "::error::Release Gate completed for $tag, but the GitHub Release was not published."
+          exit 1
+
+      - name: Dispatch the exact Gitee mirror
+        if: steps.release.outputs.should_sync == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run sync-gitee.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f "tag=$TAG"
+          echo "Dispatched Gitee mirror for $TAG"

--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -103,21 +103,27 @@ jobs:
           git -C "$mirror_dir" push --progress --force --prune gitee \
             'refs/tags/*:refs/tags/*'
 
+      # A main-branch push happens before the tagged release has finished
+      # building. Only mirror release metadata/assets from a release, schedule,
+      # or explicit dispatch so "latest" cannot lag by one publication.
       - name: Check out release sync script
+        if: github.event_name != 'push'
         uses: actions/checkout@v4
 
       - name: Install release sync dependency
+        if: github.event_name != 'push'
         run: >-
           python -m pip install --disable-pip-version-check
           "requests>=2.32,<3"
           "requests-toolbelt>=1,<2"
 
       - name: Mirror GitHub Releases and assets
+        if: github.event_name != 'push'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
           PYTHONUNBUFFERED: "1"
-          SYNC_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'push' && 'latest' || '' }}
+          SYNC_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event_name == 'release' && github.event.release.tag_name || '' }}
         run: python .github/scripts/sync_gitee_releases.py
 
       - name: Remove SSH credentials

--- a/backend/tests/test_gitee_release_sync_workflow.py
+++ b/backend/tests/test_gitee_release_sync_workflow.py
@@ -1,0 +1,46 @@
+"""Gitee release mirroring must run after GitHub finishes publishing assets."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def test_main_push_mirrors_code_without_selecting_the_previous_release():
+    workflow = (WORKFLOWS / "sync-gitee.yml").read_text(encoding="utf-8")
+
+    release_start = workflow.index("- name: Check out release sync script")
+    release_end = workflow.index("- name: Remove SSH credentials")
+    release_steps = workflow[release_start:release_end]
+
+    assert release_steps.count("if: github.event_name != 'push'") == 3
+    assert "github.event_name == 'push' && 'latest'" not in workflow
+    assert "github.event_name == 'workflow_dispatch' && inputs.tag" in workflow
+    assert "github.event_name == 'release' && github.event.release.tag_name" in workflow
+
+
+def test_successful_release_gate_dispatches_the_exact_published_tag():
+    workflow = (WORKFLOWS / "sync-gitee-after-release.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "workflow_run:" in workflow
+    assert 'workflows: ["Release Gate"]' in workflow
+    assert "types: [completed]" in workflow
+    assert "actions: write" in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "github.event.workflow_run.event == 'push'" in workflow
+    assert "git ls-remote --tags" in workflow
+    assert 'gh release view "$tag"' in workflow
+    assert "gh workflow run sync-gitee.yml" in workflow
+    assert "--ref main" in workflow
+    assert '-f "tag=$TAG"' in workflow
+
+
+def test_scheduled_sync_remains_as_a_recovery_path():
+    workflow = (WORKFLOWS / "sync-gitee.yml").read_text(encoding="utf-8")
+
+    assert 'cron: "17 2 * * *"' in workflow
+    assert "GITEE_RELEASE_RETENTION_COUNT: \"3\"" in workflow


### PR DESCRIPTION
## 问题

`main` 推送会立即运行 Gitee 同步，但此时新标签的安装包仍在 Release Gate 中构建，GitHub Release 尚未发布。同步任务因此只能拿到上一个版本；而 Release Gate 使用 `GITHUB_TOKEN` 创建 Release 后，`release: published` 不会可靠触发下一条工作流，于是 Gitee 长期表现为慢一个版本。

## 修复

- `main` 推送只同步分支和已有标签，不再提前执行 Release/附件镜像；
- 新增 `workflow_run` 后置工作流，等待 `Release Gate` 成功完成；
- 根据 Release Gate 的 `head_sha` 精确解析对应 `v*` 标签；
- 等待该 GitHub Release 可见后，通过 `workflow_dispatch` 触发 `sync-gitee.yml`，并传入精确标签；
- 保留每日定时同步，作为网络或 Gitee API 临时失败后的恢复路径；
- 新增回归测试，锁定“main 不同步旧 latest”和“发布完成后按精确标签同步”的契约。

## 预期结果

以后发布 `v3.x.x` 时，流程变为：

`Release Gate 构建并发布 GitHub Release → 后置工作流识别精确标签 → Gitee 同步该版本及附件`

不再依赖下一次 `main` 推送把上一个版本补过去。