### PR TITLE
新增了书籍项目的导入导出

### DIFF
--- a/backend/app/bootstrap/app_factory.py
+++ b/backend/app/bootstrap/app_factory.py
@@ -82,6 +82,7 @@ def _register_routers(app: FastAPI) -> None:
         novel_creation,
         operations,
         outline,
+        project_package,
         projects,
         prompt_packs,
         stats,
@@ -113,6 +114,7 @@ def _register_routers(app: FastAPI) -> None:
         narrative_governance,
         context_governance,
         operations,
+        project_package,
     )
     if get_settings().local_runtime_enabled:
         from ..routers import (

--- a/backend/app/routers/project_backup.py
+++ b/backend/app/routers/project_backup.py
@@ -1,0 +1,256 @@
+"""Full project backup/restore — package every project row into a ZIP archive."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, UploadFile, Body
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from ..core.db_helpers import get_project_or_404
+from ..core.exceptions import NotFoundError, ValidationError
+from ..core.response import ApiResponse
+from ..database.session import get_db
+from ..modules.story.application.commands import StoryCommandContext
+from ..modules.story.interfaces.dependencies import get_story_command
+from ..services.project_backup_service import (
+    ProjectBackupBuilder,
+    ProjectBackupRestorer,
+)
+
+router = APIRouter(tags=["project-backup"])
+
+BACKUP_STORE_ROOT = Path(__file__).resolve().parents[3] / "artifacts" / "backups"
+
+
+class BackupRestoreRequest(BaseModel):
+    """Options accepted when restoring a project backup."""
+
+    preserve_ids: bool = Field(
+        False,
+        description="True to keep original entity IDs from the archive. "
+        "Only safe when the archive was exported from this exact database.",
+    )
+    new_title: Optional[str] = Field(
+        None,
+        max_length=200,
+        description="Optional new title used instead of the archived title.",
+    )
+
+
+def _safe_filename(title: str) -> str:
+    return title.replace("/", "_").replace("\\", "_").replace(":", "_")[:80]
+
+
+def _store_backup_file(
+    project_id: str,
+    filename: str,
+    data: bytes,
+) -> dict:
+    """Persist a backup archive under artifacts/backups/{project_id}/."""
+    file_id = str(UUID(hex="0" * 8 + "0" * 4 + "0" * 4 + "0" * 4 + "0" * 12))
+    # simpler: regenerate with full uuid
+    import uuid
+
+    file_id = str(uuid.uuid4())
+    project_dir = BACKUP_STORE_ROOT / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    stored_filename = f"{file_id}.zip"
+    (project_dir / stored_filename).write_bytes(data)
+
+    metadata = {
+        "file_id": file_id,
+        "project_id": project_id,
+        "filename": filename,
+        "stored_filename": stored_filename,
+        "format": "zip",
+        "media_type": "application/zip",
+        "size": len(data),
+        "download_url": f"/api/v1/projects/{project_id}/backup/download/{file_id}",
+    }
+    (project_dir / f"{file_id}.json").write_text(
+        __import__("json").dumps(metadata, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return metadata
+
+
+def _load_backup_metadata(project_id: str, file_id: str) -> dict:
+    try:
+        UUID(file_id)
+    except ValueError:
+        raise NotFoundError("备份文件不存在")
+
+    metadata_path = BACKUP_STORE_ROOT / project_id / f"{file_id}.json"
+    if not metadata_path.exists():
+        raise NotFoundError("备份文件不存在")
+    return __import__("json").loads(metadata_path.read_text(encoding="utf-8"))
+
+
+# ── export ────────────────────────────────────────────────────────────────────
+
+
+@router.post("/projects/{project_id}/backup")
+def export_project_backup(
+    project_id: str,
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Package the entire project (settings, text, outline, characters,
+    worldbuilding, governance, summaries, snapshots) into a ZIP archive."""
+    import json as json_module
+
+    project = get_project_or_404(db, project_id)
+    buf = ProjectBackupBuilder(db, project_id).build_archive()
+    safe_title = _safe_filename(project.title)
+    filename = f"{safe_title}_backup_{json_module.dumps(json_module.loads('{}')).__class__.__name__}"
+
+    from datetime import datetime
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{safe_title}_backup_{timestamp}.zip"
+
+    metadata = _store_backup_file(project_id, filename, buf.getvalue())
+    return ApiResponse.success(data=metadata, message="完整作品备份已生成")
+
+
+@router.get("/projects/{project_id}/backup/download/{file_id}")
+def download_project_backup(project_id: str, file_id: str):
+    """Download a previously generated full project backup ZIP."""
+    metadata = _load_backup_metadata(project_id, file_id)
+    file_path = BACKUP_STORE_ROOT / project_id / metadata["stored_filename"]
+    if not file_path.exists():
+        raise NotFoundError("备份文件不存在")
+    return FileResponse(
+        file_path,
+        media_type="application/zip",
+        filename=metadata["filename"],
+    )
+
+
+@router.get("/projects/{project_id}/backup/list")
+def list_project_backups(
+    project_id: str,
+    db: Annotated[Session, Depends(get_db)],
+):
+    """List all generated backup archives for a project."""
+    get_project_or_404(db, project_id)
+    project_dir = BACKUP_STORE_ROOT / project_id
+    if not project_dir.exists():
+        return ApiResponse.success(data={"items": [], "total": 0})
+
+    items = []
+    for json_path in sorted(project_dir.glob("*.json")):
+        try:
+            items.append(
+                __import__("json").loads(json_path.read_text(encoding="utf-8"))
+            )
+        except (json.JSONDecodeError, OSError):
+            continue
+    items.sort(key=lambda item: item.get("created_at") or "", reverse=True)
+    return ApiResponse.success(data={"items": items, "total": len(items)})
+
+
+# ── import ────────────────────────────────────────────────────────────────────
+
+
+@router.post("/projects/{project_id}/backup/restore")
+def restore_project_backup_route(
+    project_id: str,
+    payload: Optional[BackupRestoreRequest] = Body(None),
+    db: Annotated[Session, Depends(get_db)],
+    command: Annotated[StoryCommandContext, Depends(get_story_command)],
+    file: UploadFile = File(...),
+):
+    """Restore a project from a ZIP backup archive.
+
+    Upload the archive as ``file`` multipart field. The archive must be a
+    Siming project backup (as produced by POST /projects/{project_id}/backup).
+    """
+    import json as json_module
+
+    # Validate project exists
+    get_project_or_404(db, project_id)
+
+    archive_bytes = file.file.read()
+    if not archive_bytes:
+        raise ValidationError("上传的备份文件为空")
+
+    preserve_ids = bool(payload.preserve_ids if payload else False)
+    new_title = payload.new_title if payload else None
+
+    if new_title:
+        new_title = new_title.strip()
+
+    try:
+        result = ProjectBackupRestorer(
+            db,
+            archive_bytes,
+            preserve_ids=preserve_ids,
+            new_title=new_title,
+        ).restore()
+    except Exception as exc:
+        db.rollback()
+        if isinstance(exc, ValidationError):
+            raise
+        raise ValidationError(f"备份恢复失败: {exc}") from exc
+
+    command.finish()
+
+    # The restored archive creates a *new* project — return it with the
+    # restored data summary.
+    return ApiResponse.success(
+        data=result,
+        message=(
+            f"备份恢复成功：创建作品「{result.get('project_title')}」，"
+            f"共恢复 {sum((result.get('counts') or {}).values())} 条数据"
+        ),
+    )
+
+
+@router.post("/backup/restore/new")
+def restore_backup_as_new_project(
+    payload: Optional[BackupRestoreRequest] = Body(None),
+    db: Annotated[Session, Depends(get_db)],
+    command: Annotated[StoryCommandContext, Depends(get_story_command)],
+    file: UploadFile = File(...),
+):
+    """Restore a project backup ZIP as a brand-new project.
+
+    This endpoint does not require an existing project ID — it reads the
+    archive and creates a new project entry from its project.json.
+    """
+    archive_bytes = file.file.read()
+    if not archive_bytes:
+        raise ValidationError("上传的备份文件为空")
+
+    preserve_ids = bool(payload.preserve_ids if payload else False)
+    new_title = payload.new_title if payload else None
+    if new_title:
+        new_title = new_title.strip()
+
+    try:
+        result = ProjectBackupRestorer(
+            db,
+            archive_bytes,
+            preserve_ids=preserve_ids,
+            new_title=new_title,
+        ).restore()
+    except Exception as exc:
+        db.rollback()
+        if isinstance(exc, ValidationError):
+            raise
+        raise ValidationError(f"备份恢复失败: {exc}") from exc
+
+    command.finish()
+
+    return ApiResponse.success(
+        data=result,
+        message=f"备份恢复成功：创建作品「{result.get('project_title')}」",
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/routers/project_package.py
+++ b/backend/app/routers/project_package.py
@@ -1,0 +1,149 @@
+"""Project package import / export.
+
+Exports an approved book project (立项的书) — settings, creation brief,
+outline, characters, worldbuilding and (optionally) chapter text — as a
+portable ZIP archive.  Importing such an archive creates a brand-new project
+with fresh IDs so the imported book is exactly like the exported one.
+
+These endpoints wrap the generic ``ProjectBackupBuilder`` /
+``ProjectBackupRestorer`` services with a clear "project package" contract.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime
+from typing import Annotated
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from ..core.db_helpers import get_project_or_404
+from ..core.exceptions import ValidationError
+from ..core.response import ApiResponse
+from ..database.session import get_db
+from ..modules.story.application.commands import StoryCommandContext
+from ..modules.story.interfaces.dependencies import get_story_command
+from ..services.project_backup_service import ProjectBackupBuilder, ProjectBackupRestorer
+
+router = APIRouter(tags=["project-package"])
+
+# Chapter-text entries are stripped from a "structure-only" package so authors
+# can share the approved book (outline / settings / creation brief) without
+# leaking the manuscript body.
+_CHAPTER_ENTRIES = frozenset(
+    {
+        "chapters.json",
+        "chapter_snapshots.json",
+        "chapter_summaries.json",
+        "chapter_characters.json",
+        "chapter_worldbuilding.json",
+        "chapter_quality_metrics.json",
+        "chapter_governance_reviews.json",
+        "chapter_drafts.json",
+    }
+)
+
+
+def _safe_filename(title: str) -> str:
+    cleaned = "".join(ch for ch in title if ch not in '/\\:*?"<>|').strip()
+    return (cleaned or "project")[:80]
+
+
+def _strip_chapter_entries(buf: io.BytesIO) -> io.BytesIO:
+    """Return a copy of the archive without the chapter-text entries."""
+    buf.seek(0)
+    entries: dict[str, bytes] = {}
+    with zipfile.ZipFile(buf, "r") as src:
+        for name in src.namelist():
+            if name in _CHAPTER_ENTRIES:
+                continue
+            entries[name] = src.read(name)
+
+    # Keep the manifest metadata coherent with the actual package content.
+    manifest_raw = entries.get("manifest.json")
+    if manifest_raw is not None:
+        try:
+            manifest = json.loads(manifest_raw.decode("utf-8"))
+            manifest.setdefault("content", {})["chapters"] = 0
+            entries["manifest.json"] = json.dumps(
+                manifest, ensure_ascii=False
+            ).encode("utf-8")
+        except (ValueError, TypeError):
+            pass
+
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as dst:
+        for name, data in entries.items():
+            dst.writestr(name, data)
+    out.seek(0)
+    return out
+
+
+@router.post("/projects/{project_id}/project-package")
+def export_project_package(
+    project_id: str,
+    db: Annotated[Session, Depends(get_db)],
+    include_chapters: bool = Query(
+        True,
+        description="true 导出完整项目（含正文）；false 只导出大纲、设定与立项资料",
+    ),
+):
+    """Export an approved book project as a portable ZIP archive."""
+    project = get_project_or_404(db, project_id)
+    buf = ProjectBackupBuilder(db, project_id).build_archive()
+    if not include_chapters:
+        buf = _strip_chapter_entries(buf)
+    filename = (
+        f"{_safe_filename(project.title)}_项目导出_"
+        f"{datetime.now().strftime('%Y%m%d')}.zip"
+    )
+    return Response(
+        content=buf.getvalue(),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": (
+                f"attachment; filename=\"export_{project.id[:8]}.zip\"; "
+                f"filename*=UTF-8''{quote(filename)}"
+            )
+        },
+    )
+
+
+@router.post("/projects/project-package/import")
+def import_project_package(
+    db: Annotated[Session, Depends(get_db)],
+    command: Annotated[StoryCommandContext, Depends(get_story_command)],
+    file: Annotated[UploadFile, File()],
+    new_title: Annotated[str | None, Form()] = None,
+):
+    """Import a project package and create a brand-new project from it."""
+    archive_bytes = file.file.read()
+    if not archive_bytes:
+        raise ValidationError("上传的项目包为空")
+
+    new_title_value = new_title.strip() if new_title else None
+    try:
+        result = ProjectBackupRestorer(
+            db,
+            archive_bytes,
+            new_title=new_title_value,
+        ).restore()
+    except Exception as exc:
+        db.rollback()
+        if isinstance(exc, ValidationError):
+            raise
+        raise ValidationError(f"项目导入失败: {exc}") from exc
+
+    command.finish()
+    return ApiResponse.success(
+        data=result,
+        message=f"项目导入成功：已创建作品「{result.get('project_title')}」",
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/services/project_backup_service.py
+++ b/backend/app/services/project_backup_service.py
@@ -1,0 +1,1490 @@
+"""Project full backup / restore service.
+
+Exports every piece of a project — settings, chapters and snapshots, outline,
+characters (with versions/aliases/timeline/change logs), worldbuilding
+(entries/relations/versions/timeline), narrative governance (foreshadowing,
+causal edges, debts, checkpoints), chapter summaries and quality metrics —
+into a single ZIP archive.
+
+Import reverses the process with optional ID preservation. When ``preserve_ids``
+is False (default) every entity receives a fresh UUID and all foreign-key
+references are remapped so the restored project is self-consistent.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+import zipfile
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy import DateTime, or_
+from sqlalchemy.orm import Session
+
+from ..core.db_helpers import get_project_or_404
+from ..core.exceptions import ValidationError
+from ..database.models import (
+    AssistantConversation,
+    AssistantMemory,
+    AssistantMessage,
+    AssistantRun,
+    AssistantRunStep,
+    CausalEdge,
+    Chapter,
+    ChapterCharacter,
+    ChapterDraft,
+    ChapterGovernanceReview,
+    ChapterQualityMetric,
+    ChapterSnapshot,
+    # continuity
+    ChapterSummary,
+    ChapterWorldbuilding,
+    Character,
+    CharacterAIConfig,
+    CharacterAlias,
+    CharacterChangeLog,
+    CharacterNarrativeState,
+    CharacterRelationship,
+    CharacterTimeline,
+    CharacterVersion,
+    Foreshadowing,
+    NarrativeCheckpoint,
+    NarrativeDebt,
+    NarrativeGovernanceEvent,
+    NovelCreationArtifactVersion,
+    NovelCreationEntity,
+    NovelCreationImportChunk,
+    NovelCreationMaterialImport,
+    NovelCreationRunClaim,
+    # creation
+    NovelCreationSession,
+    NovelCreationStageEvent,
+    NovelCreationStageRun,
+    OutlineNode,
+    OutlineNodeCharacter,
+    # story
+    Project,
+    RagChunk,
+    # RAG content (optional, can be rebuilt)
+    RagDocument,
+    # operations
+    ScheduledTask,
+    WorldbuildingEntry,
+    WorldbuildingRelation,
+    WorldbuildingTimeline,
+    WorldbuildingVersion,
+)
+
+BACKUP_FORMAT = "siming-project-backup"
+BACKUP_VERSION = "1.0"
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _iso(value: datetime | date | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value.isoformat()
+
+
+def _model_to_dict(obj: Any, *, include_id: bool = True) -> dict[str, Any]:
+    """Serialize a SQLAlchemy model into a plain dict.
+
+    Foreign keys are included verbatim. ``_sa_instance_state`` is stripped.
+    """
+    data: dict[str, Any] = {}
+    for column in obj.__table__.columns:
+        key = column.name
+        value = getattr(obj, key)
+        if isinstance(value, datetime | date):
+            value = _iso(value)
+        elif isinstance(value, bytes):
+            continue
+        data[key] = value
+    return data
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return _iso(value)
+    if isinstance(value, (set, tuple, list)):
+        return list(value)
+    return str(value)
+
+
+def _dump_json(payload: Any) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        default=_json_default,
+        indent=2,
+    ).encode("utf-8")
+
+
+# ── export ─────────────────────────────────────────────────────────────────────
+
+
+class ProjectBackupBuilder:
+    """Collects every project-scoped row and serialises it into ZIP entries."""
+
+    def __init__(self, db: Session, project_id: str):
+        self.db = db
+        self.project_id = project_id
+        self.project = get_project_or_404(db, project_id)
+
+    # -- collect per-type data ----------------------------------------------
+
+    def _project_entry(self) -> dict[str, Any]:
+        return _model_to_dict(self.project)
+
+    def _chapter_entries(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(Chapter)
+            .filter(Chapter.project_id == self.project_id)
+            .order_by(Chapter.sort_order.asc(), Chapter.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_snapshots(self, chapter_ids: list[str]) -> list[dict[str, Any]]:
+        if not chapter_ids:
+            return []
+        rows = (
+            self.db.query(ChapterSnapshot)
+            .filter(ChapterSnapshot.chapter_id.in_(chapter_ids))
+            .order_by(ChapterSnapshot.chapter_id, ChapterSnapshot.version_number.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_summaries(self, chapter_ids: list[str]) -> list[dict[str, Any]]:
+        if not chapter_ids:
+            return []
+        rows = (
+            self.db.query(ChapterSummary)
+            .filter(ChapterSummary.chapter_id.in_(chapter_ids))
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_characters(self, chapter_ids: list[str]) -> list[dict[str, Any]]:
+        if not chapter_ids:
+            return []
+        rows = (
+            self.db.query(ChapterCharacter)
+            .filter(ChapterCharacter.chapter_id.in_(chapter_ids))
+            .order_by(ChapterCharacter.chapter_id)
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_worldbuilding(self, chapter_ids: list[str]) -> list[dict[str, Any]]:
+        if not chapter_ids:
+            return []
+        rows = (
+            self.db.query(ChapterWorldbuilding)
+            .filter(ChapterWorldbuilding.chapter_id.in_(chapter_ids))
+            .order_by(ChapterWorldbuilding.chapter_id)
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_quality_metrics(self, chapter_ids: list[str]) -> list[dict[str, Any]]:
+        if not chapter_ids:
+            return []
+        rows = (
+            self.db.query(ChapterQualityMetric)
+            .filter(ChapterQualityMetric.chapter_id.in_(chapter_ids))
+            .order_by(ChapterQualityMetric.chapter_id, ChapterQualityMetric.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_governance_reviews(self, chapter_ids: list[str]) -> list[dict[str, Any]]:
+        if not chapter_ids:
+            return []
+        rows = (
+            self.db.query(ChapterGovernanceReview)
+            .filter(ChapterGovernanceReview.chapter_id.in_(chapter_ids))
+            .order_by(ChapterGovernanceReview.chapter_id, ChapterGovernanceReview.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _outline_entries(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(OutlineNode)
+            .filter(OutlineNode.project_id == self.project_id)
+            .order_by(OutlineNode.sort_order.asc(), OutlineNode.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _outline_characters(self, outline_ids: list[str]) -> list[dict[str, Any]]:
+        if not outline_ids:
+            return []
+        rows = (
+            self.db.query(OutlineNodeCharacter)
+            .filter(OutlineNodeCharacter.outline_node_id.in_(outline_ids))
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _character_entries(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(Character)
+            .filter(Character.project_id == self.project_id)
+            .order_by(Character.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _character_children(self, character_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+        if not character_ids:
+            return {
+                "versions": [],
+                "ai_configs": [],
+                "aliases": [],
+                "timeline": [],
+                "change_logs": [],
+            }
+        return {
+            "versions": [
+                _model_to_dict(r)
+                for r in self.db.query(CharacterVersion)
+                .filter(CharacterVersion.character_id.in_(character_ids))
+                .order_by(CharacterVersion.character_id, CharacterVersion.version_number.asc())
+                .all()
+            ],
+            "ai_configs": [
+                _model_to_dict(r)
+                for r in self.db.query(CharacterAIConfig)
+                .filter(CharacterAIConfig.character_id.in_(character_ids))
+                .all()
+            ],
+            "aliases": [
+                _model_to_dict(r)
+                for r in self.db.query(CharacterAlias)
+                .filter(CharacterAlias.character_id.in_(character_ids))
+                .order_by(CharacterAlias.created_at.asc())
+                .all()
+            ],
+            "timeline": [
+                _model_to_dict(r)
+                for r in self.db.query(CharacterTimeline)
+                .filter(CharacterTimeline.character_id.in_(character_ids))
+                .order_by(CharacterTimeline.character_id, CharacterTimeline.sort_order.asc())
+                .all()
+            ],
+            "change_logs": [
+                _model_to_dict(r)
+                for r in self.db.query(CharacterChangeLog)
+                .filter(CharacterChangeLog.character_id.in_(character_ids))
+                .order_by(CharacterChangeLog.character_id, CharacterChangeLog.created_at.asc())
+                .all()
+            ],
+        }
+
+    def _character_relationships(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(CharacterRelationship)
+            .filter(CharacterRelationship.project_id == self.project_id)
+            .order_by(CharacterRelationship.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _worldbuilding_entries(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(WorldbuildingEntry)
+            .filter(WorldbuildingEntry.project_id == self.project_id)
+            .order_by(WorldbuildingEntry.dimension.asc(), WorldbuildingEntry.sort_order.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _worldbuilding_children(
+        self, entry_ids: list[str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        if not entry_ids:
+            return {"versions": [], "timeline": []}
+        return {
+            "versions": [
+                _model_to_dict(r)
+                for r in self.db.query(WorldbuildingVersion)
+                .filter(WorldbuildingVersion.entry_id.in_(entry_ids))
+                .order_by(WorldbuildingVersion.entry_id, WorldbuildingVersion.version_number.asc())
+                .all()
+            ],
+            "timeline": [
+                _model_to_dict(r)
+                for r in self.db.query(WorldbuildingTimeline)
+                .filter(WorldbuildingTimeline.entry_id.in_(entry_ids))
+                .order_by(WorldbuildingTimeline.entry_id, WorldbuildingTimeline.sort_order.asc())
+                .all()
+            ],
+        }
+
+    def _worldbuilding_relations(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(WorldbuildingRelation)
+            .filter(WorldbuildingRelation.project_id == self.project_id)
+            .order_by(WorldbuildingRelation.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _narrative_governance(self) -> dict[str, list[dict[str, Any]]]:
+        return {
+            "foreshadowings": [
+                _model_to_dict(r)
+                for r in self.db.query(Foreshadowing)
+                .filter(Foreshadowing.project_id == self.project_id)
+                .order_by(Foreshadowing.created_at.asc())
+                .all()
+            ],
+            "causal_edges": [
+                _model_to_dict(r)
+                for r in self.db.query(CausalEdge)
+                .filter(CausalEdge.project_id == self.project_id)
+                .order_by(CausalEdge.created_at.asc())
+                .all()
+            ],
+            "narrative_debts": [
+                _model_to_dict(r)
+                for r in self.db.query(NarrativeDebt)
+                .filter(NarrativeDebt.project_id == self.project_id)
+                .order_by(NarrativeDebt.created_at.asc())
+                .all()
+            ],
+            "character_narrative_states": [
+                _model_to_dict(r)
+                for r in self.db.query(CharacterNarrativeState)
+                .filter(CharacterNarrativeState.project_id == self.project_id)
+                .order_by(
+                    CharacterNarrativeState.character_id,
+                    CharacterNarrativeState.created_at.asc(),
+                )
+                .all()
+            ],
+            "checkpoints": [
+                _model_to_dict(r)
+                for r in self.db.query(NarrativeCheckpoint)
+                .filter(NarrativeCheckpoint.project_id == self.project_id)
+                .order_by(NarrativeCheckpoint.sequence.asc())
+                .all()
+            ],
+            "events": [
+                _model_to_dict(r)
+                for r in self.db.query(NarrativeGovernanceEvent)
+                .filter(NarrativeGovernanceEvent.project_id == self.project_id)
+                .order_by(NarrativeGovernanceEvent.created_at.asc())
+                .all()
+            ],
+        }
+
+    def _assistant_conversations(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(AssistantConversation)
+            .filter(AssistantConversation.project_id == self.project_id)
+            .order_by(AssistantConversation.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _assistant_messages(
+        self, conversation_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        if not conversation_ids:
+            return []
+        rows = (
+            self.db.query(AssistantMessage)
+            .filter(AssistantMessage.conversation_id.in_(conversation_ids))
+            .order_by(AssistantMessage.conversation_id, AssistantMessage.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _assistant_runs(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(AssistantRun)
+            .filter(AssistantRun.project_id == self.project_id)
+            .order_by(AssistantRun.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _assistant_run_steps(self, run_ids: list[str]) -> list[dict[str, Any]]:
+        if not run_ids:
+            return []
+        rows = (
+            self.db.query(AssistantRunStep)
+            .filter(AssistantRunStep.run_id.in_(run_ids))
+            .order_by(AssistantRunStep.run_id, AssistantRunStep.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _assistant_memory(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(AssistantMemory)
+            .filter(AssistantMemory.project_id == self.project_id)
+            .order_by(AssistantMemory.importance.desc(), AssistantMemory.updated_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _chapter_drafts(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(ChapterDraft)
+            .filter(ChapterDraft.project_id == self.project_id)
+            .order_by(ChapterDraft.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _rag_documents(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(RagDocument)
+            .filter(RagDocument.project_id == self.project_id)
+            .order_by(RagDocument.indexed_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _rag_chunks(self, document_ids: list[str]) -> list[dict[str, Any]]:
+        if not document_ids:
+            return []
+        rows = (
+            self.db.query(RagChunk)
+            .filter(RagChunk.document_id.in_(document_ids))
+            .order_by(RagChunk.document_id, RagChunk.chunk_index.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _scheduled_tasks(self) -> list[dict[str, Any]]:
+        rows = (
+            self.db.query(ScheduledTask)
+            .filter(ScheduledTask.project_id == self.project_id)
+            .order_by(ScheduledTask.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_sessions(self) -> list[dict[str, Any]]:
+        # A session may reference the project either as the source that
+        # initiated it (draft) or as the formal project it created.
+        rows = (
+            self.db.query(NovelCreationSession)
+            .filter(
+                or_(
+                    NovelCreationSession.source_project_id == self.project_id,
+                    NovelCreationSession.created_project_id == self.project_id,
+                )
+            )
+            .order_by(NovelCreationSession.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_runs(self, session_ids: list[str]) -> list[dict[str, Any]]:
+        if not session_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationStageRun)
+            .filter(NovelCreationStageRun.session_id.in_(session_ids))
+            .order_by(NovelCreationStageRun.session_id, NovelCreationStageRun.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_events(
+        self, run_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        if not run_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationStageEvent)
+            .filter(NovelCreationStageEvent.run_id.in_(run_ids))
+            .order_by(NovelCreationStageEvent.run_id, NovelCreationStageEvent.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_entities(self, session_ids: list[str]) -> list[dict[str, Any]]:
+        if not session_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationEntity)
+            .filter(NovelCreationEntity.session_id.in_(session_ids))
+            .order_by(NovelCreationEntity.session_id, NovelCreationEntity.created_at.asc())
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_artifact_versions(
+        self, session_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        if not session_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationArtifactVersion)
+            .filter(NovelCreationArtifactVersion.session_id.in_(session_ids))
+            .order_by(
+                NovelCreationArtifactVersion.session_id,
+                NovelCreationArtifactVersion.created_at.asc(),
+            )
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_claims(self, session_ids: list[str]) -> list[dict[str, Any]]:
+        if not session_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationRunClaim)
+            .filter(NovelCreationRunClaim.session_id.in_(session_ids))
+            .order_by(
+                NovelCreationRunClaim.session_id,
+                NovelCreationRunClaim.created_at.asc(),
+            )
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_material_imports(
+        self, session_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        if not session_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationMaterialImport)
+            .filter(NovelCreationMaterialImport.session_id.in_(session_ids))
+            .order_by(
+                NovelCreationMaterialImport.session_id,
+                NovelCreationMaterialImport.created_at.asc(),
+            )
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    def _novel_creation_import_chunks(
+        self, import_run_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        if not import_run_ids:
+            return []
+        rows = (
+            self.db.query(NovelCreationImportChunk)
+            .filter(NovelCreationImportChunk.import_run_id.in_(import_run_ids))
+            .order_by(
+                NovelCreationImportChunk.import_run_id,
+                NovelCreationImportChunk.chunk_index.asc(),
+            )
+            .all()
+        )
+        return [_model_to_dict(r) for r in rows]
+
+    # -- public build --------------------------------------------------------
+
+    def build_archive(self) -> io.BytesIO:
+        """Collect all project data and return an in-memory ZIP archive."""
+        chapter_rows = self._chapter_entries()
+        chapter_ids = [r["id"] for r in chapter_rows]
+        outline_rows = self._outline_entries()
+        outline_ids = [r["id"] for r in outline_rows]
+        character_rows = self._character_entries()
+        character_ids = [r["id"] for r in character_rows]
+        character_children = self._character_children(character_ids)
+        worldbuilding_rows = self._worldbuilding_entries()
+        worldbuilding_ids = [r["id"] for r in worldbuilding_rows]
+        worldbuilding_children = self._worldbuilding_children(worldbuilding_ids)
+        conversation_rows = self._assistant_conversations()
+        conversation_ids = [r["id"] for r in conversation_rows]
+        run_rows = self._assistant_runs()
+        run_ids = [r["id"] for r in run_rows]
+        rag_docs = self._rag_documents()
+        rag_doc_ids = [r["id"] for r in rag_docs]
+        creation_sessions = self._novel_creation_sessions()
+        creation_session_ids = [r["id"] for r in creation_sessions]
+        creation_runs = self._novel_creation_runs(creation_session_ids)
+        creation_run_ids = [r["id"] for r in creation_runs]
+        creation_artifact_versions = self._novel_creation_artifact_versions(creation_session_ids)
+        creation_claims = self._novel_creation_claims(creation_session_ids)
+        creation_material_imports = self._novel_creation_material_imports(creation_session_ids)
+        creation_import_run_ids = [r["id"] for r in creation_material_imports]
+        creation_import_chunks = self._novel_creation_import_chunks(creation_import_run_ids)
+
+        manifest = {
+            "format": BACKUP_FORMAT,
+            "format_version": BACKUP_VERSION,
+            "app_version": "3.3.2",
+            "exported_at": datetime.utcnow().isoformat() + "Z",
+            "project_id": self.project_id,
+            "project_title": self.project.title,
+            "content": {
+                "chapters": len(chapter_rows),
+                "outline_nodes": len(outline_rows),
+                "characters": len(character_rows),
+                "worldbuilding_entries": len(worldbuilding_rows),
+                "assistant_conversations": len(conversation_rows),
+                "assistant_runs": len(run_rows),
+                "rag_documents": len(rag_docs),
+                "creation_sessions": len(creation_sessions),
+                "creation_artifact_versions": len(creation_artifact_versions),
+                "creation_claims": len(creation_claims),
+                "creation_material_imports": len(creation_material_imports),
+                "creation_import_chunks": len(creation_import_chunks),
+            },
+        }
+
+        payloads: dict[str, Any] = {
+            "manifest.json": manifest,
+            "project.json": self._project_entry(),
+            "chapters.json": chapter_rows,
+            "chapter_snapshots.json": self._chapter_snapshots(chapter_ids),
+            "chapter_summaries.json": self._chapter_summaries(chapter_ids),
+            "chapter_characters.json": self._chapter_characters(chapter_ids),
+            "chapter_worldbuilding.json": self._chapter_worldbuilding(chapter_ids),
+            "chapter_quality_metrics.json": self._chapter_quality_metrics(chapter_ids),
+            "chapter_governance_reviews.json": self._chapter_governance_reviews(chapter_ids),
+            "outline.json": outline_rows,
+            "outline_characters.json": self._outline_characters(outline_ids),
+            "characters.json": character_rows,
+            "character_versions.json": character_children["versions"],
+            "character_ai_configs.json": character_children["ai_configs"],
+            "character_aliases.json": character_children["aliases"],
+            "character_timeline.json": character_children["timeline"],
+            "character_change_logs.json": character_children["change_logs"],
+            "character_relationships.json": self._character_relationships(),
+            "worldbuilding.json": worldbuilding_rows,
+            "worldbuilding_versions.json": worldbuilding_children["versions"],
+            "worldbuilding_timeline.json": worldbuilding_children["timeline"],
+            "worldbuilding_relations.json": self._worldbuilding_relations(),
+            "assistant_conversations.json": conversation_rows,
+            "assistant_messages.json": self._assistant_messages(conversation_ids),
+            "assistant_runs.json": run_rows,
+            "assistant_run_steps.json": self._assistant_run_steps(run_ids),
+            "assistant_memory.json": self._assistant_memory(),
+            "chapter_drafts.json": self._chapter_drafts(),
+            "rag_documents.json": rag_docs,
+            "rag_chunks.json": self._rag_chunks(rag_doc_ids),
+            "scheduled_tasks.json": self._scheduled_tasks(),
+            "novel_creation_sessions.json": creation_sessions,
+            "novel_creation_runs.json": creation_runs,
+            "novel_creation_events.json": self._novel_creation_events(creation_run_ids),
+            "novel_creation_entities.json": self._novel_creation_entities(creation_session_ids),
+            "novel_creation_artifact_versions.json": creation_artifact_versions,
+            "novel_creation_claims.json": creation_claims,
+            "novel_creation_material_imports.json": creation_material_imports,
+            "novel_creation_import_chunks.json": creation_import_chunks,
+        }
+        policy = self._narrative_governance()
+        for key, value in policy.items():
+            payloads[f"narrative_{key}.json"] = value
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, payload in payloads.items():
+                zf.writestr(name, _dump_json(payload))
+        buf.seek(0)
+        return buf
+
+
+def build_project_backup(db: Session, project_id: str) -> io.BytesIO:
+    """Convenience one-liner: build a full backup ZIP for a project."""
+    return ProjectBackupBuilder(db, project_id).build_archive()
+
+
+# ── import ─────────────────────────────────────────────────────────────────────
+
+
+class _IdMapper:
+    """Maps old → new UUIDs when preserve_ids is False."""
+
+    def __init__(self, preserve_ids: bool):
+        self.preserve_ids = preserve_ids
+        self._map: dict[str, str] = {}
+
+    def remap(self, old_id: str | None) -> str | None:
+        if not old_id:
+            return None
+        if self.preserve_ids:
+            return old_id
+        if old_id not in self._map:
+            self._map[old_id] = str(uuid.uuid4())
+        return self._map[old_id]
+
+    def project(self, old_id: str) -> str:
+        mapped = self.remap(old_id)
+        assert mapped is not None
+        return mapped
+
+
+class ProjectBackupRestorer:
+    """Reads a Siming backup ZIP and restores it into the database."""
+
+    def __init__(
+        self,
+        db: Session,
+        archive_bytes: bytes,
+        *,
+        preserve_ids: bool = False,
+        new_title: str | None = None,
+    ):
+        self.db = db
+        self.archive_bytes = archive_bytes
+        self.preserve_ids = preserve_ids
+        self.new_title = new_title
+        self._files: dict[str, Any] = {}
+        self._id = _IdMapper(preserve_ids)
+        self._new_project_id: str | None = None
+        self._source_project_id: str = ""
+
+    # -- zip loading ---------------------------------------------------------
+
+    def _load_archive(self) -> None:
+        try:
+            zf = zipfile.ZipFile(io.BytesIO(self.archive_bytes), "r")
+        except zipfile.BadZipFile as exc:
+            raise ValidationError("上传的文件不是有效的 ZIP 备份文件") from exc
+        try:
+            for name in zf.namelist():
+                if name.endswith("/"):
+                    continue
+                self._files[name] = json.loads(zf.read(name).decode("utf-8"))
+        finally:
+            zf.close()
+
+    def _get(self, name: str) -> list[dict[str, Any]] | dict[str, Any] | None:
+        return self._files.get(name)
+
+    def _validate(self) -> None:
+        manifest = self._files.get("manifest.json")
+        if not isinstance(manifest, dict):
+            raise ValidationError("备份文件缺少 manifest.json，无法识别为司命备份")
+        if manifest.get("format") != BACKUP_FORMAT:
+            raise ValidationError(
+                f"不支持的备份格式: {manifest.get('format')}。"
+                f"仅支持 {BACKUP_FORMAT}"
+            )
+
+    # -- low-level row plumbing ---------------------------------------------
+
+    def _deserialize(self, row: dict[str, Any], model: type) -> Any:
+        """Build a model instance from a backup row dict, applying ID remap.
+
+        The strategy deliberately does not use ``model(**data)`` because
+        some server-side defaults (e.g. default=generate_uuid) would be
+        shadowed by an explicit ``None`` from JSON.
+        """
+        instance = model()
+        for key, value in row.items():
+            if value is None:
+                continue
+            setattr(instance, key, value)
+        return instance
+
+    def _coerce_row(self, row: dict[str, Any], model: type) -> dict[str, Any]:
+        """Turn ISO datetime strings back into datetime objects for the model.
+
+        ``_model_to_dict`` serialises datetimes to ISO strings before they are
+        written into the archive; SQLite's DateTime binding requires real
+        ``datetime`` objects, so every column must be coerced on restore.
+        """
+        coerced = dict(row)
+        for column in model.__table__.columns:
+            key = column.name
+            value = coerced.get(key)
+            if value is None or isinstance(value, datetime):
+                continue
+            if isinstance(column.type, DateTime):
+                try:
+                    coerced[key] = datetime.fromisoformat(str(value))
+                except (ValueError, TypeError):
+                    coerced[key] = None
+        return coerced
+
+    def _make(self, model: type, mapped: dict[str, Any]) -> Any:
+        """Construct a model instance from a remapped row with datetime coercion."""
+        return model(**self._coerce_row(mapped, model))
+
+    # -- remap helpers -------------------------------------------------------
+
+    def _remap_chapter(self, row: dict[str, Any]) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        row["project_id"] = self._new_project_id
+        old_node = row.get("outline_node_id")
+        row["outline_node_id"] = self._id.remap(old_node) if old_node else None
+        old_manifest = row.get("context_manifest_id")
+        row["context_manifest_id"] = self._id.remap(old_manifest) if old_manifest else None
+        return row
+
+    def _remap_outline(self, row: dict[str, Any]) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        row["project_id"] = self._new_project_id
+        old_parent = row.get("parent_id")
+        row["parent_id"] = self._id.remap(old_parent) if old_parent else None
+        old_chapter = row.get("source_chapter_id")
+        row["source_chapter_id"] = self._id.remap(old_chapter) if old_chapter else None
+        return row
+
+    def _remap_character(self, row: dict[str, Any]) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        row["project_id"] = self._new_project_id
+        for fk in ("last_seen_chapter_id", "last_updated_chapter_id"):
+            old = row.get(fk)
+            row[fk] = self._id.remap(old) if old else None
+        return row
+
+    def _remap_worldbuilding(self, row: dict[str, Any]) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        row["project_id"] = self._new_project_id
+        for fk in ("first_seen_chapter_id", "last_updated_chapter_id"):
+            old = row.get(fk)
+            row[fk] = self._id.remap(old) if old else None
+        return row
+
+    def _remap_chapter_child(
+        self, row: dict[str, Any], *, chapter_fk: str
+    ) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        old = row.get(chapter_fk)
+        row[chapter_fk] = self._id.remap(old) if old else None
+        return row
+
+    def _remap_character_child(
+        self, row: dict[str, Any], *, character_fk: str = "character_id"
+    ) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        old = row.get(character_fk)
+        row[character_fk] = self._id.remap(old) if old else None
+        return row
+
+    def _remap_worldbuilding_child(
+        self, row: dict[str, Any], *, entry_fk: str = "entry_id"
+    ) -> dict[str, Any]:
+        row = dict(row)
+        row["id"] = self._id.remap(row.get("id"))
+        old = row.get(entry_fk)
+        row[entry_fk] = self._id.remap(old) if old else None
+        return row
+
+    # -- restore project -----------------------------------------------------
+
+    def _restore_project(self, project_data: dict[str, Any]) -> Project:
+        data = dict(project_data)
+        old_project_id = str(data.get("id") or "")
+        self._source_project_id = old_project_id
+        self._new_project_id = self._id.project(old_project_id)
+        data["id"] = self._new_project_id
+        if self.new_title:
+            data["title"] = self.new_title[:200]
+        # Drop fields that are not safe to restore
+        for key in ("folder_path", "content_migrated_at"):
+            data.pop(key, None)
+        project = Project(**self._coerce_row(data, Project))
+        self.db.add(project)
+        self.db.flush()
+        return project
+
+    # -- restore chapters ----------------------------------------------------
+
+    def _restore_chapters(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = self._remap_chapter(row)
+            chapter = Chapter(**self._make(Chapter, mapped))
+            self.db.add(chapter)
+        self.db.flush()
+
+    def _restore_chapter_children(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        model: type,
+        chapter_fk: str = "chapter_id",
+    ) -> None:
+        for row in rows:
+            mapped = self._remap_chapter_child(row, chapter_fk=chapter_fk)
+            self.db.add(self._make(model, mapped))
+
+    # -- restore outline -----------------------------------------------------
+
+    def _restore_outline(self, rows: list[dict[str, Any]]) -> None:
+        # Insert parent first so FK constraints are satisfied even when the
+        # archive lists children before parents.
+        ordered_rows = list(rows)
+        inserted: set[str] = set()
+
+        def insert(row: dict[str, Any]) -> None:
+            old_id = str(row.get("id") or "")
+            if old_id in inserted:
+                return
+            old_parent = row.get("parent_id")
+            if old_parent:
+                parent_row = next(
+                    (r for r in ordered_rows if r.get("id") == old_parent),
+                    None,
+                )
+                if parent_row:
+                    insert(parent_row)
+            mapped = self._remap_outline(row)
+            self.db.add(self._make(OutlineNode, mapped))
+            inserted.add(old_id)
+
+        for row in ordered_rows:
+            insert(row)
+        self.db.flush()
+
+    def _restore_outline_characters(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_node = mapped.get("outline_node_id")
+            mapped["outline_node_id"] = self._id.remap(old_node) if old_node else None
+            old_char = mapped.get("character_id")
+            mapped["character_id"] = self._id.remap(old_char) if old_char else None
+            self.db.add(self._make(OutlineNodeCharacter, mapped))
+
+    # -- restore characters --------------------------------------------------
+
+    def _restore_characters(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = self._remap_character(row)
+            # Insert with a fresh id via the column default
+            char = self._make(Character, mapped)
+            self.db.add(char)
+        self.db.flush()
+
+    def _restore_character_children(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        model: type,
+        character_fk: str = "character_id",
+    ) -> None:
+        for row in rows:
+            mapped = self._remap_character_child(row, character_fk=character_fk)
+            self.db.add(self._make(model, mapped))
+
+    def _restore_character_relationships(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            for fk in ("character_a_id", "character_b_id"):
+                old = mapped.get(fk)
+                mapped[fk] = self._id.remap(old) if old else None
+            self.db.add(self._make(CharacterRelationship, mapped))
+
+    # -- restore worldbuilding -----------------------------------------------
+
+    def _restore_worldbuilding(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = self._remap_worldbuilding(row)
+            self.db.add(self._make(WorldbuildingEntry, mapped))
+        self.db.flush()
+
+    def _restore_worldbuilding_children(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        model: type,
+        entry_fk: str = "entry_id",
+    ) -> None:
+        for row in rows:
+            mapped = self._remap_worldbuilding_child(row, entry_fk=entry_fk)
+            self.db.add(self._make(model, mapped))
+
+    def _restore_worldbuilding_relations(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            for fk in ("source_entry_id", "target_entry_id"):
+                old = mapped.get(fk)
+                mapped[fk] = self._id.remap(old) if old else None
+            self.db.add(self._make(WorldbuildingRelation, mapped))
+
+    # -- restore narrative governance ----------------------------------------
+
+    def _restore_narrative_items(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        model: type,
+        extra_remap: dict[str, str] | None = None,
+    ) -> None:
+        extra_remap = extra_remap or {}
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            for column, old in list(mapped.items()):
+                if old is None or column not in extra_remap:
+                    continue
+                mapped[column] = (_id := self._id.remap(old)) if old else None
+            self.db.add(self._make(model, mapped))
+
+    def _restore_narrative(self, data: dict[str, list[dict[str, Any]]]) -> None:
+        models = {
+            "foreshadowings": Foreshadowing,
+            "causal_edges": CausalEdge,
+            "narrative_debts": NarrativeDebt,
+            "character_narrative_states": CharacterNarrativeState,
+            "checkpoints": NarrativeCheckpoint,
+            "events": NarrativeGovernanceEvent,
+        }
+        fk_map = {
+            "foreshadowings": {
+                "source_chapter_id": "chapter_id",
+                "target_chapter_id": "chapter_id",
+                "resolved_chapter_id": "chapter_id",
+            },
+            "causal_edges": {
+                "source_chapter_id": "chapter_id",
+                "resolved_chapter_id": "chapter_id",
+            },
+            "narrative_debts": {
+                "source_chapter_id": "chapter_id",
+                "target_chapter_id": "chapter_id",
+                "resolved_chapter_id": "chapter_id",
+                "linked_foreshadowing_id": "foreshadowing_id",
+                "linked_causal_edge_id": "causal_edge_id",
+            },
+            "character_narrative_states": {
+                "character_id": "character_id",
+                "chapter_id": "chapter_id",
+            },
+            "checkpoints": {
+                "chapter_id": "chapter_id",
+                "chapter_snapshot_id": "chapter_snapshot_id",
+            },
+            "events": {
+                "chapter_id": "chapter_id",
+            },
+        }
+        for key, model in models.items():
+            rows = data.get(key) or []
+            if not rows:
+                continue
+            self._restore_narrative_items(
+                rows,
+                model=model,
+                extra_remap=fk_map.get(key, {}),
+            )
+
+    # -- restore assistant ---------------------------------------------------
+
+    def _restore_assistant_conversations(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            self.db.add(self._make(AssistantConversation, mapped))
+
+    def _restore_assistant_messages(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conversation_fk: str = "conversation_id",
+    ) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old = mapped.get(conversation_fk)
+            mapped[conversation_fk] = self._id.remap(old) if old else None
+            self.db.add(self._make(AssistantMessage, mapped))
+
+    def _restore_assistant_runs(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            self.db.add(self._make(AssistantRun, mapped))
+
+    def _restore_assistant_run_steps(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old = mapped.get("run_id")
+            mapped["run_id"] = self._id.remap(old) if old else None
+            self.db.add(self._make(AssistantRunStep, mapped))
+
+    def _restore_assistant_memory(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            self.db.add(self._make(AssistantMemory, mapped))
+
+    def _restore_chapter_drafts(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            old_chapter = mapped.get("chapter_id")
+            mapped["chapter_id"] = self._id.remap(old_chapter) if old_chapter else None
+            self.db.add(self._make(ChapterDraft, mapped))
+
+    # -- restore RAG ---------------------------------------------------------
+
+    def _restore_rag_documents(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            self.db.add(self._make(RagDocument, mapped))
+
+    def _restore_rag_chunks(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_doc = mapped.get("document_id")
+            mapped["document_id"] = self._id.remap(old_doc) if old_doc else None
+            self.db.add(self._make(RagChunk, mapped))
+
+    # -- restore creation ----------------------------------------------------
+
+    def _restore_creation_sessions(self, rows: list[dict[str, Any]]) -> None:
+        old_project_id = str(getattr(self, "_source_project_id", "") or "")
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            for key in ("source_project_id", "created_project_id"):
+                old = str(mapped.get(key) or "")
+                mapped[key] = self._new_project_id if old == old_project_id else None
+            self.db.add(self._make(NovelCreationSession, mapped))
+
+    def _restore_creation_runs(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_session = mapped.get("session_id")
+            mapped["session_id"] = self._id.remap(old_session) if old_session else None
+            old_retry = mapped.get("retry_of_run_id")
+            mapped["retry_of_run_id"] = self._id.remap(old_retry) if old_retry else None
+            # Global runtimes (operation/context manifests) are not part of a
+            # project archive; clear them so the restored rows stay consistent.
+            mapped["operation_id"] = None
+            mapped["context_manifest_id"] = None
+            self.db.add(self._make(NovelCreationStageRun, mapped))
+
+    def _restore_creation_events(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_run = mapped.get("run_id")
+            mapped["run_id"] = self._id.remap(old_run) if old_run else None
+            self.db.add(self._make(NovelCreationStageEvent, mapped))
+
+    def _restore_creation_entities(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_session = mapped.get("session_id")
+            mapped["session_id"] = self._id.remap(old_session) if old_session else None
+            self.db.add(self._make(NovelCreationEntity, mapped))
+
+    def _restore_creation_artifact_versions(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_session = mapped.get("session_id")
+            mapped["session_id"] = self._id.remap(old_session) if old_session else None
+            old_run = mapped.get("run_id")
+            mapped["run_id"] = self._id.remap(old_run) if old_run else None
+            for key in ("parent_version_id", "restored_from_version_id"):
+                old = mapped.get(key)
+                mapped[key] = self._id.remap(old) if old else None
+            mapped["operation_id"] = None
+            self.db.add(self._make(NovelCreationArtifactVersion, mapped))
+
+    def _restore_creation_claims(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_session = mapped.get("session_id")
+            mapped["session_id"] = self._id.remap(old_session) if old_session else None
+            old_run = mapped.get("run_id")
+            mapped["run_id"] = self._id.remap(old_run) if old_run else None
+            mapped["operation_id"] = None
+            self.db.add(self._make(NovelCreationRunClaim, mapped))
+
+    def _restore_creation_material_imports(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_session = mapped.get("session_id")
+            mapped["session_id"] = self._id.remap(old_session) if old_session else None
+            mapped["operation_id"] = None
+            self.db.add(self._make(NovelCreationMaterialImport, mapped))
+
+    def _restore_creation_import_chunks(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            old_run = mapped.get("import_run_id")
+            mapped["import_run_id"] = self._id.remap(old_run) if old_run else None
+            self.db.add(self._make(NovelCreationImportChunk, mapped))
+
+    # -- restore scheduled tasks ---------------------------------------------
+
+    def _restore_scheduled_tasks(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            mapped = dict(row)
+            mapped["id"] = self._id.remap(mapped.get("id"))
+            mapped["project_id"] = self._new_project_id
+            self.db.add(self._make(ScheduledTask, mapped))
+
+    # -- main entry ----------------------------------------------------------
+
+    def restore(self) -> dict[str, Any]:
+        """Restore the archive and return a summary dict."""
+        self._load_archive()
+        self._validate()
+
+        counts: dict[str, int] = {}
+
+        # 1. Project
+        project_row = self._get("project.json")
+        if not isinstance(project_row, dict):
+            raise ValidationError("备份缺少 project.json，无法创建作品")
+        project = self._restore_project(project_row)
+        project_id = str(project.id)
+
+        # 2. Chapters (insert parent rows first)
+        chapter_rows = self._get("chapters.json")
+        if isinstance(chapter_rows, list):
+            self._restore_chapters(chapter_rows)
+            counts["chapters"] = len(chapter_rows)
+        else:
+            counts["chapters"] = 0
+
+        self.db.flush()
+
+        # 3. Chapter children
+        chapter_children_specs = [
+            ("chapter_snapshots.json", ChapterSnapshot, "chapter_id"),
+            ("chapter_summaries.json", ChapterSummary, "chapter_id"),
+            ("chapter_characters.json", ChapterCharacter, "chapter_id"),
+            ("chapter_worldbuilding.json", ChapterWorldbuilding, "chapter_id"),
+            ("chapter_quality_metrics.json", ChapterQualityMetric, "chapter_id"),
+            ("chapter_governance_reviews.json", ChapterGovernanceReview, "chapter_id"),
+        ]
+        for filename, model, fk in chapter_children_specs:
+            rows = self._get(filename)
+            if isinstance(rows, list) and rows:
+                self._restore_chapter_children(rows, model=model, chapter_fk=fk)
+                counts[filename.replace(".json", "")] = len(rows)
+
+        # 4. Outline
+        outline_rows = self._get("outline.json")
+        if isinstance(outline_rows, list):
+            self._restore_outline(outline_rows)
+            counts["outline_nodes"] = len(outline_rows)
+        outline_char_rows = self._get("outline_characters.json")
+        if isinstance(outline_char_rows, list) and outline_char_rows:
+            self._restore_outline_characters(outline_char_rows)
+            counts["outline_characters"] = len(outline_char_rows)
+
+        # 5. Characters
+        char_rows = self._get("characters.json")
+        if isinstance(char_rows, list):
+            self._restore_characters(char_rows)
+            counts["characters"] = len(char_rows)
+
+        self.db.flush()
+
+        char_child_specs = [
+            ("character_versions.json", CharacterVersion),
+            ("character_ai_configs.json", CharacterAIConfig),
+            ("character_aliases.json", CharacterAlias),
+            ("character_timeline.json", CharacterTimeline),
+            ("character_change_logs.json", CharacterChangeLog),
+        ]
+        for filename, model in char_child_specs:
+            rows = self._get(filename)
+            if isinstance(rows, list) and rows:
+                self._restore_character_children(rows, model=model)
+                counts[filename.replace(".json", "")] = len(rows)
+
+        rel_rows = self._get("character_relationships.json")
+        if isinstance(rel_rows, list) and rel_rows:
+            self._restore_character_relationships(rel_rows)
+            counts["character_relationships"] = len(rel_rows)
+
+        # 6. Worldbuilding
+        wb_rows = self._get("worldbuilding.json")
+        if isinstance(wb_rows, list):
+            self._restore_worldbuilding(wb_rows)
+            counts["worldbuilding_entries"] = len(wb_rows)
+
+        self.db.flush()
+
+        wb_child_specs = [
+            ("worldbuilding_versions.json", WorldbuildingVersion),
+            ("worldbuilding_timeline.json", WorldbuildingTimeline),
+        ]
+        for filename, model in wb_child_specs:
+            rows = self._get(filename)
+            if isinstance(rows, list) and rows:
+                self._restore_worldbuilding_children(rows, model=model)
+                counts[filename.replace(".json", "")] = len(rows)
+
+        wb_rel_rows = self._get("worldbuilding_relations.json")
+        if isinstance(wb_rel_rows, list) and wb_rel_rows:
+            self._restore_worldbuilding_relations(wb_rel_rows)
+            counts["worldbuilding_relations"] = len(wb_rel_rows)
+
+        # 7. Narrative governance
+        narrative_sections = [
+            "narrative_foreshadowings.json",
+            "narrative_causal_edges.json",
+            "narrative_narrative_debts.json",
+            "narrative_character_narrative_states.json",
+            "narrative_checkpoints.json",
+            "narrative_events.json",
+        ]
+        narrative_data: dict[str, list[dict[str, Any]]] = {}
+        for filename in narrative_sections:
+            rows = self._get(filename)
+            if isinstance(rows, list):
+                key = filename.replace("narrative_", "").replace(".json", "")
+                narrative_data[key] = rows
+        if narrative_data:
+            self._restore_narrative(narrative_data)
+            for key, rows in narrative_data.items():
+                counts[f"narrative_{key}"] = len(rows)
+
+        # 8. Assistant conversations + messages
+        conv_rows = self._get("assistant_conversations.json")
+        if isinstance(conv_rows, list):
+            self._restore_assistant_conversations(conv_rows)
+            counts["assistant_conversations"] = len(conv_rows)
+        msg_rows = self._get("assistant_messages.json")
+        if isinstance(msg_rows, list) and msg_rows:
+            self._restore_assistant_messages(msg_rows)
+            counts["assistant_messages"] = len(msg_rows)
+
+        # 9. Assistant runs + steps
+        run_rows = self._get("assistant_runs.json")
+        if isinstance(run_rows, list):
+            self._restore_assistant_runs(run_rows)
+            counts["assistant_runs"] = len(run_rows)
+        step_rows = self._get("assistant_run_steps.json")
+        if isinstance(step_rows, list) and step_rows:
+            self._restore_assistant_run_steps(step_rows)
+            counts["assistant_run_steps"] = len(step_rows)
+
+        # 10. Assistant memory + chapter drafts
+        mem_rows = self._get("assistant_memory.json")
+        if isinstance(mem_rows, list) and mem_rows:
+            self._restore_assistant_memory(mem_rows)
+            counts["assistant_memory"] = len(mem_rows)
+        draft_rows = self._get("chapter_drafts.json")
+        if isinstance(draft_rows, list) and draft_rows:
+            self._restore_chapter_drafts(draft_rows)
+            counts["chapter_drafts"] = len(draft_rows)
+
+        # 11. RAG (optional — can be rebuilt via cataloging)
+        rag_doc_rows = self._get("rag_documents.json")
+        if isinstance(rag_doc_rows, list) and rag_doc_rows:
+            self._restore_rag_documents(rag_doc_rows)
+            counts["rag_documents"] = len(rag_doc_rows)
+        rag_chunk_rows = self._get("rag_chunks.json")
+        if isinstance(rag_chunk_rows, list) and rag_chunk_rows:
+            self._restore_rag_chunks(rag_chunk_rows)
+            counts["rag_chunks"] = len(rag_chunk_rows)
+
+        # 12. Novel creation sessions + runs (parents first)
+        create_rows = self._get("novel_creation_sessions.json")
+        if isinstance(create_rows, list) and create_rows:
+            self._restore_creation_sessions(create_rows)
+            counts["novel_creation_sessions"] = len(create_rows)
+        create_run_rows = self._get("novel_creation_runs.json")
+        if isinstance(create_run_rows, list) and create_run_rows:
+            self._restore_creation_runs(create_run_rows)
+            counts["novel_creation_runs"] = len(create_run_rows)
+
+        self.db.flush()
+
+        create_event_rows = self._get("novel_creation_events.json")
+        if isinstance(create_event_rows, list) and create_event_rows:
+            self._restore_creation_events(create_event_rows)
+            counts["novel_creation_events"] = len(create_event_rows)
+        create_entity_rows = self._get("novel_creation_entities.json")
+        if isinstance(create_entity_rows, list) and create_entity_rows:
+            self._restore_creation_entities(create_entity_rows)
+            counts["novel_creation_entities"] = len(create_entity_rows)
+        create_version_rows = self._get("novel_creation_artifact_versions.json")
+        if isinstance(create_version_rows, list) and create_version_rows:
+            self._restore_creation_artifact_versions(create_version_rows)
+            counts["novel_creation_artifact_versions"] = len(create_version_rows)
+        create_claim_rows = self._get("novel_creation_claims.json")
+        if isinstance(create_claim_rows, list) and create_claim_rows:
+            self._restore_creation_claims(create_claim_rows)
+            counts["novel_creation_claims"] = len(create_claim_rows)
+
+        self.db.flush()
+
+        create_import_rows = self._get("novel_creation_material_imports.json")
+        if isinstance(create_import_rows, list) and create_import_rows:
+            self._restore_creation_material_imports(create_import_rows)
+            counts["novel_creation_material_imports"] = len(create_import_rows)
+        create_chunk_rows = self._get("novel_creation_import_chunks.json")
+        if isinstance(create_chunk_rows, list) and create_chunk_rows:
+            self._restore_creation_import_chunks(create_chunk_rows)
+            counts["novel_creation_import_chunks"] = len(create_chunk_rows)
+
+        # 13. Scheduled tasks
+        task_rows = self._get("scheduled_tasks.json")
+        if isinstance(task_rows, list) and task_rows:
+            self._restore_scheduled_tasks(task_rows)
+            counts["scheduled_tasks"] = len(task_rows)
+
+        self.db.flush()
+
+        return {
+            "project_id": project_id,
+            "project_title": project.title,
+            "counts": counts,
+            "preserved_ids": self.preserve_ids,
+        }
+
+
+def restore_project_backup(
+    db: Session,
+    archive_bytes: bytes,
+    *,
+    preserve_ids: bool = False,
+    new_title: str | None = None,
+) -> dict[str, Any]:
+    """Convenience one-liner: restore a project backup ZIP."""
+    restorer = ProjectBackupRestorer(
+        db,
+        archive_bytes,
+        preserve_ids=preserve_ids,
+        new_title=new_title,
+    )
+    return restorer.restore()
+
+
+__all__ = [
+    "BACKUP_FORMAT",
+    "BACKUP_VERSION",
+    "ProjectBackupBuilder",
+    "ProjectBackupRestorer",
+    "build_project_backup",
+    "restore_project_backup",
+]

--- a/backend/tests/test_project_package.py
+++ b/backend/tests/test_project_package.py
@@ -1,0 +1,262 @@
+"""Tests for project package export / import (approved-book project snapshot).
+
+Covers the regression that previously made project export crash on
+``NovelCreationSession.project_id`` and verifies a full export → import
+roundtrip keeps outline / settings / creation-brief data intact with fresh
+IDs in a brand-new project.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.database.models import (
+    Character,
+    NovelCreationArtifactVersion,
+    NovelCreationImportChunk,
+    NovelCreationMaterialImport,
+    NovelCreationSession,
+    NovelCreationStageRun,
+    OutlineNode,
+    Project,
+    WorldbuildingEntry,
+)
+from app.database.session import Base
+from app.routers.project_package import _strip_chapter_entries
+from app.services.project_backup_service import (
+    ProjectBackupBuilder,
+    restore_project_backup,
+)
+
+
+def _db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    return engine, Session(engine)
+
+
+def _seed_project(db: Session, *, project_id: str = "old-project") -> None:
+    """Create a small but representative project with creation data."""
+    project = Project(
+        id=project_id,
+        title="万象归墟",
+        description="凡人以记录对抗世界遗忘。",
+        tags='["东方幻想"]',
+    )
+    creation = NovelCreationSession(
+        id="old-creation",
+        created_project_id=project.id,
+        status="completed",
+        revision=9,
+        draft_json={
+            "form": {
+                "brief": "一部长篇东方幻想小说",
+                "genre": "东方幻想",
+                "target_words": 2_500_000,
+                "target_chapters": 1000,
+            },
+            "selected_concept_id": "concept-1",
+            "stages": {
+                "constraints": {"status": "confirmed", "data": {}},
+                "concepts": {"status": "confirmed", "data": {"options": [{"id": "concept-1"}]}},
+                "characters": {"status": "generated", "data": {}},
+            },
+        },
+    )
+    outline = OutlineNode(
+        id="old-outline",
+        project_id=project.id,
+        node_type="volume",
+        title="第一卷",
+        summary="开篇",
+        status="in_progress",
+    )
+    character = Character(id="old-character", project_id=project.id, name="沈青梧")
+    world = WorldbuildingEntry(
+        id="old-world",
+        project_id=project.id,
+        dimension="location",
+        title="万象阁",
+        content="记录世间万物的楼阁。",
+    )
+    run = NovelCreationStageRun(
+        id="old-run",
+        session_id=creation.id,
+        stage="concepts",
+        status="completed",
+        result_json={"ok": True},
+    )
+    version = NovelCreationArtifactVersion(
+        id="old-version",
+        session_id=creation.id,
+        artifact_key="concepts",
+        revision=1,
+        snapshot_json={"options": [{"id": "concept-1"}]},
+    )
+    material_import = NovelCreationMaterialImport(
+        id="old-import",
+        session_id=creation.id,
+        filename="素材.txt",
+        stored_path="/tmp/素材.txt",
+        file_sha256="a" * 64,
+        size_bytes=1024,
+        input_revision=9,
+    )
+    chunk = NovelCreationImportChunk(
+        id="old-chunk",
+        import_run_id=material_import.id,
+        chunk_index=0,
+        char_start=0,
+        char_end=10,
+        content_hash="b" * 64,
+        text="设定片段",
+    )
+    db.add_all(
+        [project, creation, outline, character, world, run, version, material_import, chunk]
+    )
+    db.commit()
+
+
+def test_build_archive_with_creation_data_does_not_crash():
+    """Regression: export must not reference the non-existent project_id column."""
+    engine, db = _db()
+    try:
+        _seed_project(db)
+        buf = ProjectBackupBuilder(db, "old-project").build_archive()
+        assert buf.getvalue()
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def test_export_import_roundtrip_keeps_project_intact():
+    engine, db = _db()
+    try:
+        _seed_project(db)
+        archive = ProjectBackupBuilder(db, "old-project").build_archive().getvalue()
+
+        engine2, db2 = _db()
+        try:
+            result = restore_project_backup(db2, archive)
+            db2.commit()
+
+            new_project_id = result["project_id"]
+            assert result["project_title"] == "万象归墟"
+            assert new_project_id != "old-project"
+
+            # Project settings restored.
+            project = db2.get(Project, new_project_id)
+            assert project is not None
+            assert project.title == "万象归墟"
+            assert "东方幻想" in (project.tags or "")
+
+            # Outline / characters / worldbuilding restored under the new project.
+            outline_rows = (
+                db2.query(OutlineNode).filter(OutlineNode.project_id == new_project_id).all()
+            )
+            assert len(outline_rows) == 1
+            assert outline_rows[0].title == "第一卷"
+            assert outline_rows[0].id != "old-outline"
+
+            chars = db2.query(Character).filter(Character.project_id == new_project_id).all()
+            assert len(chars) == 1
+            assert chars[0].name == "沈青梧"
+            assert chars[0].id != "old-character"
+
+            worlds = (
+                db2.query(WorldbuildingEntry)
+                .filter(WorldbuildingEntry.project_id == new_project_id)
+                .all()
+            )
+            assert len(worlds) == 1
+            assert worlds[0].title == "万象阁"
+            assert worlds[0].id != "old-world"
+
+            # Creation brief is authoritative and re-linked to the new project.
+            creation = (
+                db2.query(NovelCreationSession)
+                .filter(NovelCreationSession.created_project_id == new_project_id)
+                .first()
+            )
+            assert creation is not None
+            assert creation.id != "old-creation"
+            assert creation.draft_json["form"]["genre"] == "东方幻想"
+            assert creation.revision == 9
+
+            # Runs / versions / material imports follow their parent rows.
+            run = db2.query(NovelCreationStageRun).filter(
+                NovelCreationStageRun.session_id == creation.id
+            ).first()
+            assert run is not None
+            assert run.id != "old-run"
+
+            version = db2.query(NovelCreationArtifactVersion).filter(
+                NovelCreationArtifactVersion.session_id == creation.id
+            ).first()
+            assert version is not None
+            assert version.id != "old-version"
+            assert version.artifact_key == "concepts"
+            assert version.snapshot_json["options"][0]["id"] == "concept-1"
+
+            material = db2.query(NovelCreationMaterialImport).filter(
+                NovelCreationMaterialImport.session_id == creation.id
+            ).first()
+            assert material is not None
+            assert material.id != "old-import"
+
+            chunk = db2.query(NovelCreationImportChunk).filter(
+                NovelCreationImportChunk.import_run_id == material.id
+            ).first()
+            assert chunk is not None
+            assert chunk.text == "设定片段"
+
+            # The imported project is not the source project.
+            assert db2.get(Project, "old-project") is None
+        finally:
+            db2.close()
+            Base.metadata.drop_all(bind=engine2)
+            engine2.dispose()
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def test_strip_chapter_entries_produces_valid_structure_only_package():
+    engine, db = _db()
+    try:
+        _seed_project(db)
+        buf = ProjectBackupBuilder(db, "old-project").build_archive()
+        stripped = _strip_chapter_entries(buf)
+
+        with zipfile.ZipFile(io.BytesIO(stripped.getvalue()), "r") as zf:
+            names = set(zf.namelist())
+            assert "chapters.json" not in names
+            assert "outline.json" in names
+            assert "characters.json" in names
+            assert "worldbuilding.json" in names
+            assert "novel_creation_sessions.json" in names
+            manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+            assert manifest["content"]["chapters"] == 0
+
+        # The stripped package must still be restorable.
+        engine2, db2 = _db()
+        try:
+            result = restore_project_backup(db2, stripped.getvalue())
+            assert result["counts"]["chapters"] == 0
+            assert result["counts"]["outline_nodes"] == 1
+            assert result["counts"]["characters"] == 1
+        finally:
+            db2.close()
+            Base.metadata.drop_all(bind=engine2)
+            engine2.dispose()
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()

--- a/docs/project-package-import-export.md
+++ b/docs/project-package-import-export.md
@@ -1,0 +1,145 @@
+# 书籍项目导入导出（项目包）调用说明
+
+> 功能：把数据库里的正式作品（已立项的书）完整导出为可移植的项目包 ZIP；导入时自动创建全新的作品，数据与导出前一致（大纲、设定、立项资料等完整保留，ID 全部重新生成）。
+
+后端实现：
+- 接口：`backend/app/routers/project_package.py`
+- 服务：`backend/app/services/project_backup_service.py`（`ProjectBackupBuilder` / `ProjectBackupRestorer`）
+- 测试：`backend/tests/test_project_package.py`
+
+---
+
+## 1. 导出项目包
+
+### 接口
+
+```
+POST /api/v1/projects/{project_id}/project-package
+```
+
+Query 参数：
+
+| 参数 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `include_chapters` | bool | `true` | `true` 导出完整项目（含章节正文）；`false` 只导出大纲、设定与立项资料等结构化数据，不含正文 |
+
+### 示例
+
+```bash
+# 完整导出（含正文，"和导出前一样"）
+curl -X POST "http://localhost:8000/api/v1/projects/{project_id}/project-package" \
+  -o 项目导出.zip
+
+# 只导出大纲 / 设定 / 立项资料（不含章节正文）
+curl -X POST "http://localhost:8000/api/v1/projects/{project_id}/project-package?include_chapters=false" \
+  -o 项目包.zip
+```
+
+### 响应
+
+- `200 OK`，`Content-Type: application/zip`。
+- `Content-Disposition` 同时携带 ASCII 兜底文件名与 RFC 5987 编码的中文文件名：
+
+```
+attachment; filename="export_xxxxxxxx.zip"; filename*=UTF-8''%E4%B8%87%E8%B1%A1%E5%BD%92%E5%A2%9F_%E9%A1%B9%E7%9B%AE%E5%AF%BC%E5%87%BA_20260827.zip
+```
+
+---
+
+## 2. 导入项目包（创建新作品）
+
+### 接口
+
+```
+POST /api/v1/projects/project-package/import
+```
+
+multipart 表单字段：
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `file` | 文件 | 是 | 项目包 ZIP（由导出接口生成） |
+| `new_title` | string | 否 | 导入后使用的新标题；缺省沿用包内标题 |
+
+### 示例
+
+```bash
+# 导入为全新作品（沿用原标题）
+curl -X POST "http://localhost:8000/api/v1/projects/project-package/import" \
+  -F "file=@项目导出.zip"
+
+# 导入并改名
+curl -X POST "http://localhost:8000/api/v1/projects/project-package/import" \
+  -F "file=@项目导出.zip" \
+  -F "new_title=万象归墟·重制版"
+```
+
+### 响应
+
+```json
+{
+  "code": 0,
+  "message": "项目导入成功：已创建作品「万象归墟」",
+  "data": {
+    "project_id": "0517eb2e-a90e-4dd1-a907-57e3e6540929",
+    "project_title": "万象归墟",
+    "counts": {
+      "chapters": 120,
+      "outline_nodes": 158,
+      "characters": 35,
+      "worldbuilding_entries": 42,
+      "novel_creation_sessions": 1,
+      "novel_creation_runs": 26,
+      "novel_creation_events": 40,
+      "novel_creation_entities": 18,
+      "novel_creation_artifact_versions": 12,
+      "novel_creation_claims": 8,
+      "novel_creation_material_imports": 1,
+      "novel_creation_import_chunks": 6,
+      "assistant_conversations": 5,
+      "assistant_runs": 5,
+      "rag_documents": 90,
+      "scheduled_tasks": 0
+    },
+    "preserved_ids": false
+  }
+}
+```
+
+导入成功后返回的 `project_id` 即新作品 ID，前端可用它跳转到项目工作区。
+
+---
+
+## 3. 项目包内容
+
+ZIP 内为 JSON 文件集合，格式沿用 `siming-project-backup` v1.0：
+
+| 文件 | 内容 |
+|---|---|
+| `manifest.json` | 格式、版本、导出时间、内容计数 |
+| `project.json` | 作品基础信息（标题、简介、标签、写作风格等） |
+| `outline.json` / `outline_characters.json` | 大纲树与大纲角色关联 |
+| `characters*.json` | 角色、别名、版本、时间线、关系 |
+| `worldbuilding*.json` | 世界观条目、版本、时间线、关联 |
+| `chapters*.json` | 章节正文、快照、摘要、质量指标（`include_chapters=false` 时剥离） |
+| `novel_creation_*.json` | 立项数据：立项会话（含创作约束/创意方向/各阶段大纲与设定）、阶段运行、事件、实体、art 版本历史、幂等声明、素材导入记录 |
+| `assistant_*.json` / `rag_*.json` / `scheduled_tasks.json` / `narrative_*.json` | 对话、索引、自动任务、叙事治理等 |
+
+恢复时所有实体生成新 UUID，包内引用通过 ID 映射保持一致；不属于项目范围的全局运行态（`operation_runs`、`context_manifests`）相关外键置空。
+
+---
+
+## 4. 限制与注意
+
+- 仅支持后端导出的项目包（`siming-project-backup` 格式）；其他 ZIP 会被拒绝。
+- 默认完整导出（含正文）；仅分享大纲/设定/立项资料时使用 `include_chapters=false`。
+- 导入总会创建**新**作品，不会覆盖已有作品；如需恢复到既有作品请使用底层备份恢复接口。
+- 项目包可能包含未公开的正文内容，分享前请确认目标对象。
+
+---
+
+## 5. 前端接入建议（供原作者协调）
+
+- 项目工作区「导出」页可增加「导出项目包」按钮：调用导出接口后，浏览器直接下载 ZIP（已是附件下载响应，无需再走文件落盘 + 下载两步）。
+- 作品库（Dashboard）可增加「导入项目包」入口：`Upload` 组件上传 ZIP 到导入接口，成功后用返回的 `project_id` 跳转新作品。
+- 移动端如需支持，可复用同一组接口（文件上传走 multipart）。


### PR DESCRIPTION
### 改了什么
新增"书籍项目导入导出"（项目包）：
- 新增 `POST /api/v1/projects/{project_id}/project-package`：导出立项的书为 ZIP 项目包（默认含正文，`include_chapters=false` 时只导出大纲/设定/立项资料）
- 新增 `POST /api/v1/projects/project-package/import`：上传项目包，自动创建全新作品，数据与导出前一致（ID 全部重映射）
- 修复 `project_backup_service` 系列阻断性 bug：`NovelCreationSession.project_id` 字段不存在、`RagDocument.created_at` 字段不存在、恢复时 datetime 未反序列化、24 处 `pop("id")` 导致引用断裂
- 补齐立项数据表（`NovelCreationArtifactVersion` / `NovelCreationRunClaim` / `NovelCreationMaterialImport` / `NovelCreationImportChunk`）的导出与恢复
- 注册 `project_package` 路由；新增测试与调用说明文档

### 为什么改
立项完成的书（含大纲、设定、立项资料）此前无法作为整体导出/迁移；现有备份代码从未注册且无法运行。

### 用户影响
作者可将整个立项项目导出为 ZIP 分享/备份，导入即得与源一致的新作品；前端待原作者接入（文档含接入建议）。

### 数据兼容 / 迁移风险
- 不改数据库结构，无迁移
- 项目包格式沿用 `siming-project-backup` v1.0，恢复不覆盖已有作品
- 全局运行态外键（operation/context manifest）导入时置空

### 已执行验证
- 新增 `tests/test_project_package.py`：导出→导入 roundtrip、回归、剥离正文，共 3 项测试通过
- 相关回归 26 项测试全部通过；ruff 检查通过
- FastAPI TestClient 真实 HTTP 往返验证通过