### PR TITLE
docs: credit PR56 contributor @hiturf

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+# 贡献者与致谢
+
+司命感谢所有提交代码、设计、测试与反馈的社区成员。Git 提交记录和 Pull Request 是主要贡献记录；本文件补充记录原始实现未直接进入主线、但对最终方案产生实质影响的贡献。
+
+- [@hiturf](https://github.com/hiturf)（Polaris）在 [PR #56](https://github.com/teangtang1122/siming-ai/pull/56) 中提出并实现了书籍项目导入导出的早期方案。这项工作推动并影响了后续严格、版本化的司命项目包设计与实现（[PR #57](https://github.com/teangtang1122/siming-ai/pull/57)）。

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Windows Release 提供 `Siming-Setup.exe` 与 `Siming-Setup.sha256`；Android �
 
 普通使用者只需要 `Siming-Setup.exe`。以下环境仅面向源码贡献者。
 
+社区贡献及补充致谢记录在 [CONTRIBUTORS.md](CONTRIBUTORS.md)。
+
 源码开发使用 CPython 3.11。前端工具链以 `build-toolchain.json` 为准，当前为 Node.js 24.14.1 与 npm 11.11.0；Android 构建使用 JDK 17。Windows 正式打包还需要 Inno Setup，完整固定版本见 [Windows 安装与发布](PACKAGING.md)。
 
 ```powershell


### PR DESCRIPTION
## 变更

- 新增 `CONTRIBUTORS.md`，明确记录 `@hiturf`（Polaris）在 PR56 中提出并实现的早期书籍项目导入导出方案。
- 说明该工作对后续严格、版本化的司命项目包实现产生了实质影响，并链接 PR56 与替代 PR57。
- 从 README 的“开发与贡献”章节加入致谢入口。

## 贡献归属

本 PR 的提交包含 PR56 已由 GitHub 关联到 `@hiturf` 的共同作者信息：

```text
Co-authored-by: Polaris <polaris-umi@outlook.com>
```

这笔变更不会重新引入 PR56 已被替代的实现，也不会改写 `main` 或 `v3.3.3` 的既有历史。

## 验证

- `git diff --cached --check`
- 远端提交树 `fa95b21907775a03c64f96a0fa34afe389ba883a` 与本地审阅后的提交树一致
