### PR TITLE
docs: credit early MCP direction contribution

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,11 @@
 # 贡献者与致谢
 
-司命感谢所有提交代码、设计、测试与反馈的社区成员。Git 提交记录和 Pull Request 是主要贡献记录；本文件补充记录原始实现未直接进入主线、但对最终方案产生实质影响的贡献。
+司命感谢所有提交代码、设计、测试、核心思路、建议与反馈的贡献者。项目贡献不限于 Git 提交；本文件同时记录对项目方向和能力形成产生实际影响的贡献。
+
+## 核心思路与方向贡献
+
+- [@hhhh-cjx](https://github.com/hhhh-cjx) 在司命开源前提出了在项目中使用 MCP 的思路，为后续 MCP 集成与外部 Agent 协作方向提供了重要启发。
+
+## 方案与实现贡献
 
 - [@hiturf](https://github.com/hiturf)（Polaris）在 [PR #56](https://github.com/teangtang1122/siming-ai/pull/56) 中提出并实现了书籍项目导入导出的早期方案。这项工作推动并影响了后续严格、版本化的司命项目包设计与实现（[PR #57](https://github.com/teangtang1122/siming-ai/pull/57)）。


### PR DESCRIPTION
## 变更

- 明确项目贡献不限于 Git 提交，也包括对项目方向和能力形成产生实际影响的核心思路。
- 新增“核心思路与方向贡献”分类。
- 记录 `@hhhh-cjx` 在司命开源前提出项目使用 MCP 的思路，以及这项贡献对后续 MCP 集成与外部 Agent 协作方向的启发。
- 保留 `@hiturf` 的方案与实现贡献，并将两类贡献清晰区分。

## 归属边界

本 PR 将 `@hhhh-cjx` 明确列为司命项目贡献者，但不会将其误标为这笔文档提交或现有代码的作者。GitHub 自动 Contributors 统计仍由进入默认分支的提交作者信息决定。

## 验证

- `git diff --cached --check`
- 远端 blob `35a765882e0bfd25279d0554d59227b45881fe03` 与本地一致
- 远端提交树 `112d7315558da1eef143e71bfb8e33d8d7a4f01b` 与本地审阅后的提交树一致
