### PR TITLE
新增后端行为日志

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,11 @@
 DATABASE_URL=sqlite:///./novel_agent.db
 SECRET_KEY=your-secret-key-here-generate-a-long-random-string
 CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
+# Backend logging. SIMING_LOG_LEVEL accepts debug/info/warning/error/critical.
+# SIMING_LOG_FILE accepts auto/0/1 (auto writes logs/siming.log under the data
+# home for desktop/Gateway runs and only logs to stderr in bare dev servers).
+# SIMING_LOG_HTTP_ACCESS=1 enables per-request Uvicorn access lines.
+SIMING_LOG_LEVEL=info
+SIMING_LOG_FILE=auto
+SIMING_LOG_HTTP_ACCESS=0

--- a/backend/app/bootstrap/app_factory.py
+++ b/backend/app/bootstrap/app_factory.py
@@ -20,6 +20,7 @@ from ..core.exceptions import (
     general_exception_handler,
     validation_exception_handler,
 )
+from ..core.logging_setup import configure_logging
 from ..version import APP_VERSION
 from .composition import configure_application_services
 from .http_security import (
@@ -229,6 +230,7 @@ async def _no_op_lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 def create_app(*, run_startup: bool = True) -> FastAPI:
     """Build the web application; persistent work belongs to lifespan."""
+    configure_logging()
     settings = get_settings()
     configure_application_services()
     app = FastAPI(

--- a/backend/app/bootstrap/lifecycle.py
+++ b/backend/app/bootstrap/lifecycle.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 
 from ..architecture.uow import SqlAlchemyUnitOfWork
 from ..core.config import get_settings
+from ..core.logging_setup import configure_logging
 from ..database.session import SessionLocal
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,7 @@ def _schedule_context_rebuild() -> None:
             uow.commit()
         if job_id:
             asyncio.create_task(asyncio.to_thread(run_context_rebuild_job, job_id))
+            logger.info("Context rebuild job scheduled job_id=%s", job_id)
     except Exception as exc:
         logger.warning("Failed to schedule context rebuild: %s", exc)
 
@@ -177,7 +179,17 @@ async def _bootstrap_runtime(app: FastAPI) -> RuntimeBootstrapStatus:
     from ..database.bootstrap import bootstrap_database
 
     result = await asyncio.to_thread(bootstrap_database)
+    logger.info(
+        "Database bootstrap mode=%s schema_revision=%s",
+        result.mode,
+        result.schema_revision,
+    )
     if result.read_only:
+        logger.warning(
+            "Database bootstrap entered read-only recovery mode=%s message=%s",
+            result.mode,
+            result.message,
+        )
         return RuntimeBootstrapStatus(
             status="recovery",
             database_mode=result.mode,
@@ -187,7 +199,9 @@ async def _bootstrap_runtime(app: FastAPI) -> RuntimeBootstrapStatus:
         )
 
     await asyncio.to_thread(_run_legacy_startup_recovery)
+    logger.info("Legacy startup recovery finished")
     await asyncio.to_thread(_start_scheduler)
+    logger.info("Background scheduler started")
     settings = get_settings()
     if not settings.gateway_enabled:
         await asyncio.to_thread(_resume_local_runtime_jobs)
@@ -206,12 +220,14 @@ def _shutdown_runtime() -> None:
         from ..services.scheduler.engine import stop_scheduler
 
         stop_scheduler()
+        logger.info("Background scheduler stopped")
     except Exception as exc:
         logger.warning("Failed to stop scheduler: %s", exc)
     try:
         from ..services.local_runtime import get_runtime_manager
 
         get_runtime_manager().stop()
+        logger.info("Local runtime stopped")
     except Exception as exc:
         logger.warning("Failed to stop local runtime: %s", exc)
 
@@ -219,6 +235,10 @@ def _shutdown_runtime() -> None:
 @asynccontextmanager
 async def application_lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Run all stateful startup work in one observable lifecycle."""
+    # Uvicorn applies its own logging dictConfig before the lifespan starts;
+    # re-assert our console/file layout so every entry point produces the same
+    # logs regardless of the launcher that started the process.
+    configure_logging(force=True)
     loop = asyncio.get_running_loop()
     installed_handler, previous_handler = _install_windows_transport_exception_filter(loop)
     app.state.runtime_bootstrap = RuntimeBootstrapStatus()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -93,7 +93,22 @@ class Settings(BaseSettings):
             "SIMING_SYNC_TOMBSTONE_RETENTION_DAYS", "SYNC_TOMBSTONE_RETENTION_DAYS"
         ),
     )
-    
+
+    # Logging: values are kept untyped on purpose so a bad environment value can
+    # never prevent the application from starting; configure_logging() normalizes.
+    log_level: str = Field(
+        default="info",
+        validation_alias=AliasChoices("SIMING_LOG_LEVEL", "LOG_LEVEL"),
+    )
+    log_file: str = Field(
+        default="auto",
+        validation_alias=AliasChoices("SIMING_LOG_FILE", "LOG_FILE"),
+    )
+    log_http_access: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("SIMING_LOG_HTTP_ACCESS", "LOG_HTTP_ACCESS"),
+    )
+
     def get_cors_origins(self) -> list[str]:
         """Parse CORS origins from comma-separated string."""
         values = [origin.strip().rstrip("/") for origin in self.cors_origins.split(",")]

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,8 +1,13 @@
 """Global exception handling."""
+import logging
+
 from fastapi import Request
-from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
 from .response import ApiResponse
+
+logger = logging.getLogger(__name__)
 
 
 class AppException(Exception):
@@ -52,19 +57,40 @@ class LLMError(AppException):
 
 async def app_exception_handler(request: Request, exc: AppException) -> JSONResponse:
     """Handle custom application exceptions."""
+    if exc.code >= 500:
+        logger.error(
+            "Request failed with app error code=%s path=%s message=%s",
+            exc.code,
+            request.url.path,
+            exc.message,
+        )
+    else:
+        logger.warning(
+            "Request rejected code=%s path=%s message=%s",
+            exc.code,
+            request.url.path,
+            exc.message,
+        )
     return JSONResponse(
         status_code=exc.status_code,
         content=ApiResponse.error(code=exc.code, message=exc.message).model_dump()
     )
 
 
-async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
     """Handle request validation errors."""
     errors = []
     for error in exc.errors():
         loc = " -> ".join(str(x) for x in error.get("loc", []))
         errors.append(f"{loc}: {error.get('msg', '')}")
-    
+    logger.warning(
+        "Request validation failed path=%s details=%s",
+        request.url.path,
+        "; ".join(errors),
+    )
+
     return JSONResponse(
         status_code=422,
         content=ApiResponse.error(
@@ -76,6 +102,11 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 async def general_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Handle unhandled exceptions."""
+    logger.exception(
+        "Unhandled exception path=%s class=%s",
+        request.url.path,
+        type(exc).__name__,
+    )
     return JSONResponse(
         status_code=500,
         content=ApiResponse.error(

--- a/backend/app/core/logging_setup.py
+++ b/backend/app/core/logging_setup.py
@@ -1,0 +1,222 @@
+"""Centralized Python logging configuration for the Siming backend.
+
+Every backend entry point that builds the FastAPI application
+(``app.bootstrap.app_factory.create_app``) applies this layout, and the
+application lifespan re-applies it once Uvicorn has finished its own default
+``dictConfig`` so log lines land in the same console + file handlers no matter
+which launcher (desktop ``launcher.py``, Docker ``uvicorn`` CLI, CLI scripts)
+started the process.
+
+Rules kept intentionally simple:
+
+* Console (stderr) handler is always installed for non-pytest processes.
+* A rotating file handler is added when file logging is enabled (see below).
+* Only the ``app`` logger tree follows ``SIMING_LOG_LEVEL`` (default ``info``);
+  third-party loggers stay at ``warning`` so HTTP/LLM client chatter does not
+  drown the records that matter.
+* Pytest processes never install handlers or write files; the test framework
+  owns log capture.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from contextlib import suppress
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from .config import get_settings
+
+_configured = False
+
+_MAX_FILE_BYTES = 5 * 1024 * 1024
+_FILE_BACKUPS = 3
+
+_DATEFMT = "%Y-%m-%d %H:%M:%S"
+_CONSOLE_FORMAT = "%(asctime)s %(levelname)-7s [%(name)s] %(message)s"
+_FILE_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)-7s %(threadName)s [%(name)s] %(message)s"
+
+_VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _normalize_level(raw: str | None) -> int:
+    name = (raw or "info").strip().upper()
+    return getattr(logging, name) if name in _VALID_LEVELS else logging.INFO
+
+
+def _in_pytest_mode() -> bool:
+    return "pytest" in sys.modules or bool(os.environ.get("PYTEST_CURRENT_TEST"))
+
+
+def _siming_home() -> Path | None:
+    """Return SIMING_HOME when the launcher/Docker explicitly configured it."""
+    for key in ("SIMING_HOME", "MOSHU_HOME", "NOVEL_AGENT_HOME"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            try:
+                return Path(value).expanduser().resolve()
+            except OSError:
+                return None
+    return None
+
+
+def _resolve_file_enabled(
+    configured: str,
+    *,
+    home: Path | None,
+    gateway_enabled: bool,
+) -> bool:
+    raw = (configured or "auto").strip().lower()
+    if raw in _FALSE_VALUES:
+        return False
+    if raw in _TRUE_VALUES:
+        return True
+    # ``auto``: packaged desktop build, headless Gateway and desktop runs that
+    # already prepared a data home write a file; bare source/CI servers only log
+    # to stderr unless the operator explicitly enables file logging.
+    if getattr(sys, "frozen", False):
+        return True
+    if gateway_enabled:
+        return True
+    return home is not None
+
+
+def _log_file_path(home: Path | None) -> Path | None:
+    if home is None:
+        return None
+    try:
+        path = home / "logs" / "siming.log"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+    except OSError:
+        return None
+
+
+def _remove_owned_handlers() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if str(getattr(handler, "name", "") or "").startswith("siming-"):
+            root.removeHandler(handler)
+            with suppress(Exception):
+                handler.close()
+
+
+def _console_available() -> bool:
+    """Return True when a real stderr stream exists (windowed GUI builds do not)."""
+    return getattr(sys, "stderr", None) is not None
+
+
+def _clear_root_handlers() -> None:
+    """Remove every root handler; non-test processes own the logging layout."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        with suppress(Exception):
+            handler.close()
+
+
+def _install_console() -> None:
+    if not _console_available():
+        return
+    handler = logging.StreamHandler()
+    handler.name = "siming-console"
+    handler.setFormatter(logging.Formatter(_CONSOLE_FORMAT, datefmt=_DATEFMT))
+    logging.getLogger().addHandler(handler)
+
+
+def _install_file(home: Path | None) -> None:
+    path = _log_file_path(home)
+    if path is None:
+        return
+    try:
+        handler = RotatingFileHandler(
+            path,
+            maxBytes=_MAX_FILE_BYTES,
+            backupCount=_FILE_BACKUPS,
+            encoding="utf-8",
+        )
+    except OSError:
+        return
+    handler.name = "siming-file"
+    handler.setFormatter(logging.Formatter(_FILE_FORMAT, datefmt=_DATEFMT))
+    logging.getLogger().addHandler(handler)
+
+
+def _apply_levels(*, debug: bool, access_log_enabled: bool) -> None:
+    root = logging.getLogger()
+    root.setLevel(logging.WARNING)
+    # The application tree follows SIMING_LOG_LEVEL.
+    logging.getLogger("app").setLevel(logging.DEBUG if debug else logging.INFO)
+
+    # Uvicorn installs its own handlers through dictConfig at startup; replace
+    # that layout so everything flows through our console/file handlers and the
+    # access log can be enabled without a second stderr copy.
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.propagate = True
+    logging.getLogger("uvicorn").setLevel(logging.INFO)
+    logging.getLogger("uvicorn.error").setLevel(logging.INFO)
+    logging.getLogger("uvicorn.access").setLevel(
+        logging.INFO if access_log_enabled else logging.WARNING
+    )
+
+    # Migration progress is useful; ORM/HTTP client internals are not.
+    logging.getLogger("alembic").setLevel(logging.DEBUG if debug else logging.INFO)
+    for name in (
+        "sqlalchemy.engine",
+        "sqlalchemy.pool",
+        "httpx",
+        "httpcore",
+        "openai",
+        "anthropic",
+    ):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def configure_logging(*, force: bool = False) -> None:
+    """Apply the backend logging layout once per process (or on demand).
+
+    ``force=True`` is used by the application lifespan to recover from
+    Uvicorn's own default ``dictConfig`` without duplicating handlers.
+    """
+    global _configured
+    if _configured and not force:
+        return
+    _configured = True
+
+    settings = get_settings()
+    level = _normalize_level(settings.log_level)
+    home = _siming_home()
+
+    _remove_owned_handlers()
+    if _in_pytest_mode():
+        # Tests own capture; keep thresholds meaningful for caplog but never
+        # write files or claim the console.
+        logging.getLogger("app").setLevel(level)
+        return
+
+    # Fully own the root logger layout: Uvicorn's CLI dictConfig may already
+    # have attached its own handlers before the lifespan starts, and leaving
+    # them in place would duplicate records on stderr.
+    _clear_root_handlers()
+
+    _install_console()
+    if _resolve_file_enabled(
+        settings.log_file,
+        home=home,
+        gateway_enabled=bool(settings.gateway_enabled),
+    ):
+        _install_file(home)
+
+    _apply_levels(
+        debug=level == logging.DEBUG,
+        access_log_enabled=bool(settings.log_http_access),
+    )
+
+
+__all__ = ["configure_logging"]

--- a/backend/app/core/uvicorn_controller.py
+++ b/backend/app/core/uvicorn_controller.py
@@ -43,7 +43,7 @@ class UvicornServerController:
                 return False
             if self._thread and self._thread.is_alive():
                 return True
-            config = uvicorn.Config(app, **self._config_options)
+            config = uvicorn.Config(app, log_config=None, **self._config_options)
             server = uvicorn.Server(config)
             thread = threading.Thread(
                 target=server.run,

--- a/backend/app/modules/gateway/infrastructure/change_capture.py
+++ b/backend/app/modules/gateway/infrastructure/change_capture.py
@@ -219,6 +219,7 @@ def _dispatch_after_commit(session: Session) -> None:
     job_ids = list(session.info.pop(_CAPTURE_JOB_IDS, []))
     if not job_ids:
         return
+    logger.debug("Dispatching Gateway sync capture jobs=%d", len(job_ids))
     try:
         SyncCaptureProcessor(_session_factory_for(session)).process(job_ids)
         session.expire_all()

--- a/backend/app/modules/story/infrastructure/content_sync.py
+++ b/backend/app/modules/story/infrastructure/content_sync.py
@@ -365,6 +365,7 @@ def _dispatch_after_commit(session: Session) -> None:
     job_ids = list(session.info.pop(_SESSION_JOB_IDS, []))
     if not job_ids or session.info.get(_SKIP_AUTO_DISPATCH):
         return
+    logger.debug("Dispatching committed content sync jobs=%d", len(job_ids))
     try:
         ContentSyncProcessor(_session_factory_for(session)).process(job_ids)
         session.expire_all()

--- a/backend/app/routers/config_storage.py
+++ b/backend/app/routers/config_storage.py
@@ -139,16 +139,35 @@ def pick_content_root_settings(db: Session = Depends(get_db)):
     return ApiResponse.success(data=_apply_content_root(db, str(selected)), message="小说数据目录已更新")
 
 
+def _system_log_path() -> Path:
+    """Resolve the log file shown by the GUI terminal page.
+
+    Application runtime logs (``siming.log``) are preferred once they exist;
+    the legacy startup-only ``launcher.log`` remains the fallback so boot-time
+    diagnostics stay reachable.
+    """
+    home = _app_home()
+    local_app_data = os.environ.get("LOCALAPPDATA", "")
+    candidates = [
+        home / "logs" / "siming.log",
+        home / "logs" / "launcher.log",
+    ]
+    if local_app_data:
+        candidates.append(
+            Path(local_app_data) / "NovelWritingAgent" / "logs" / "launcher.log"
+        )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # No log file yet (fresh install before first server run): keep reporting
+    # the location that will exist so the UI shows an actionable path.
+    return home / "logs" / "launcher.log"
+
+
 @router.get("/system/logs")
 def get_system_logs(lines: int = 200):
-    """Read the last N lines of the launcher log file."""
-    log_path = _app_home() / "logs" / "launcher.log"
-    if not log_path.exists():
-        local_app_data = os.environ.get("LOCALAPPDATA", "")
-        if local_app_data:
-            legacy = Path(local_app_data) / "NovelWritingAgent" / "logs" / "launcher.log"
-            if legacy.exists():
-                log_path = legacy
+    """Read the last N lines of the backend runtime or launcher log file."""
+    log_path = _system_log_path()
     if not log_path.exists():
         return ApiResponse.success(data={"path": str(log_path), "content": "(log file not found)", "lines": 0})
 

--- a/backend/app/services/cataloging/launcher.py
+++ b/backend/app/services/cataloging/launcher.py
@@ -305,6 +305,14 @@ def create_and_queue_cataloging_job(
     if run_now and backend != "external_agent":
         queue_cataloging_job(job.id)
         queued = True
+        logger.info(
+            "Cataloging job queued job_id=%s project=%s chapters=%d source=%s backend=%s",
+            job.id,
+            project_id,
+            len(chapter_ids),
+            trigger_source,
+            backend,
+        )
     data = job_to_dict(job)
     data.update({
         "started": run_now,
@@ -328,6 +336,12 @@ async def run_cataloging_job(job_id: str) -> None:
         job = db.query(CatalogingJob).filter(CatalogingJob.id == job_id).first()
         if not job or job.status in _TERMINAL_JOB_STATUSES:
             return
+        logger.info(
+            "Cataloging worker start job=%s project=%s backend=%s",
+            job.id,
+            job.project_id,
+            job.execution_backend,
+        )
         if job.execution_backend == "local_cli_agent":
             ensure_local_cli_cataloging_worker(db, job, provider=job.provider)
             return

--- a/backend/app/services/local_runtime/manager.py
+++ b/backend/app/services/local_runtime/manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import secrets
@@ -27,6 +28,8 @@ from .hardware import detect_hardware
 from .paths import siming_home
 
 LOCAL_SERVER_PARALLEL_SLOTS = 1
+
+logger = logging.getLogger(__name__)
 
 
 def _hidden_process_kwargs(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) -> dict:
@@ -207,6 +210,14 @@ class LocalRuntimeManager:
                             if row:
                                 row.last_used_at = datetime.utcnow()
                                 commit_session(db)
+                        logger.info(
+                            "Local runtime ready model=%s port=%s attempt=%d context=%d task=%s",
+                            model.model_key,
+                            port,
+                            attempt + 1,
+                            attempt_context,
+                            task_type,
+                        )
                         return self.base_url or ""
                     if self._process.poll() is not None:
                         last_error = (
@@ -229,12 +240,20 @@ class LocalRuntimeManager:
                         last_error = f"{last_error}\n\nllama.cpp 日志尾部：\n{detail}"
                 self.stop()
             self._mark_runtime_error(last_error)
+            logger.error(
+                "Local runtime launch failed model=%s task=%s attempts=%d",
+                model.model_key,
+                task_type,
+                len(launch_profiles),
+            )
             raise RuntimeError(last_error)
 
     def stop(self) -> None:
         with self._lock:
             process = self._process
             port = self._port
+            stopped_model = self._model_key or "unknown"
+            stopped_pid = getattr(process, "pid", None)
             self._process = None
             self._port = None
             self._api_key = None
@@ -252,6 +271,12 @@ class LocalRuntimeManager:
                     process.kill()
             elif port:
                 self._kill_pid(self._pid_for_port(port))
+            logger.info(
+                "Local runtime stopped model=%s pid=%s port=%s",
+                stopped_model,
+                stopped_pid,
+                port,
+            )
             try:
                 with SessionLocal() as db:
                     runtime = db.query(LocalRuntimeInstallation).filter(

--- a/backend/app/services/scheduler/engine.py
+++ b/backend/app/services/scheduler/engine.py
@@ -59,10 +59,17 @@ def _execute_task(task_id: str) -> None:
         task.last_run_status = "running"
         commit_session(db)
 
+        started_at = time.monotonic()
         try:
             result = _run_task_prompt(db, task)
             task.last_run_status = "completed"
             task.last_run_output = result[:10000] if result else "完成"
+            logger.info(
+                "Scheduled task completed name=%s task_id=%s duration=%.1fs",
+                task.name,
+                task_id,
+                time.monotonic() - started_at,
+            )
         except Exception as exc:
             logger.exception("Task %s failed: %s", task_id, exc)
             task.last_run_status = "error"

--- a/backend/app/services/workspace/assistant_turn_runner.py
+++ b/backend/app/services/workspace/assistant_turn_runner.py
@@ -161,13 +161,32 @@ class WorkspaceAssistantTurnRunner:
             self._bootstrap_canonical(state)
             for event in self._setup_records(state):
                 yield event
+            run_id = getattr(state.assistant_run, "id", None)
+            logger.info(
+                "Workspace assistant turn start run=%s project=%s provider=%s model=%s mode=%s",
+                run_id,
+                self.project_id,
+                self.selected_provider or "",
+                self.payload.model,
+                "native" if supports_native else ("direct_mcp" if direct_mcp else "unsupported"),
+            )
             for event in self._configure(state):
                 yield event
             async for event in self._run_iterations(state):
                 yield event
+            logger.info(
+                "Workspace assistant turn complete run=%s project=%s",
+                getattr(state.assistant_run, "id", None),
+                self.project_id,
+            )
             yield state.event({"type": "complete", "data": self._finalize(state)})
             yield state.event("[DONE]")
         except WorkspaceTurnSuperseded:
+            logger.info(
+                "Workspace assistant turn superseded run=%s project=%s",
+                getattr(state.assistant_run, "id", None),
+                self.project_id,
+            )
             yield state.event(
                 {
                     "type": "superseded",

--- a/backend/launcher.py
+++ b/backend/launcher.py
@@ -699,11 +699,15 @@ def main() -> None:
             f"Gateway: {server_host == '0.0.0.0'}"
         )
 
+        access_log_enabled = (
+            os.environ.get("SIMING_LOG_HTTP_ACCESS", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
         server_controller = UvicornServerController(
             host=server_host,
             port=port,
             log_level="info",
-            access_log=False,
+            access_log=access_log_enabled,
         )
         instance.start_activation_listener(
             metadata={

--- a/backend/tests/test_logging_setup.py
+++ b/backend/tests/test_logging_setup.py
@@ -1,0 +1,198 @@
+"""Tests for the centralized backend logging configuration.
+
+These tests exercise ``app.core.logging_setup`` in isolation.  Inside a pytest
+process ``configure_logging`` never installs handlers or writes files; tests
+that want the real console/file layout opt out of the pytest guard with a
+localized monkeypatch.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from app.core import logging_setup
+from app.core.logging_setup import configure_logging
+
+
+@pytest.fixture()
+def clean_logging():
+    """Reset module state and remove any siming-owned handlers between tests."""
+    root = logging.getLogger()
+    initial_level = root.level
+    logging_setup._configured = False
+    yield
+    for handler in list(root.handlers):
+        if str(getattr(handler, "name", "") or "").startswith("siming-"):
+            root.removeHandler(handler)
+            handler.close()
+    root.setLevel(initial_level)
+    logging_setup._configured = False
+
+
+def _owned_handler_names() -> set[str]:
+    return {
+        str(getattr(handler, "name", "") or "")
+        for handler in logging.getLogger().handlers
+        if str(getattr(handler, "name", "") or "").startswith("siming-")
+    }
+
+
+def test_pytest_process_never_installs_handlers(clean_logging):
+    configure_logging()
+    assert _owned_handler_names() == set()
+
+
+def test_console_and_file_handlers_are_installed(clean_logging, tmp_path, monkeypatch):
+    monkeypatch.setattr(logging_setup, "_in_pytest_mode", lambda: False)
+    monkeypatch.setenv("SIMING_HOME", str(tmp_path))
+    monkeypatch.setenv("SIMING_LOG_FILE", "1")
+
+    configure_logging()
+    assert _owned_handler_names() == {"siming-console", "siming-file"}
+
+    # Idempotent: repeated calls (e.g. app factory per entry point) do not
+    # duplicate handlers.
+    configure_logging()
+    matches = [
+        handler
+        for handler in logging.getLogger().handlers
+        if str(getattr(handler, "name", "") or "") == "siming-file"
+    ]
+    assert len(matches) == 1
+
+    logging.getLogger("app.siming.test").info("hello-siming-log")
+    matches[0].flush()
+    content = (tmp_path / "logs" / "siming.log").read_text(encoding="utf-8")
+    assert "hello-siming-log" in content
+    assert "siming-console" in _owned_handler_names()
+
+
+def test_file_logging_auto_is_disabled_without_data_home(clean_logging, monkeypatch):
+    monkeypatch.setattr(logging_setup, "_in_pytest_mode", lambda: False)
+    monkeypatch.delenv("SIMING_HOME", raising=False)
+    monkeypatch.delenv("MOSHU_HOME", raising=False)
+    monkeypatch.delenv("NOVEL_AGENT_HOME", raising=False)
+    monkeypatch.setenv("SIMING_LOG_FILE", "auto")
+
+    configure_logging()
+    assert _owned_handler_names() == {"siming-console"}
+
+
+def test_file_logging_auto_is_enabled_when_home_is_configured(clean_logging, tmp_path, monkeypatch):
+    monkeypatch.setattr(logging_setup, "_in_pytest_mode", lambda: False)
+    monkeypatch.setenv("SIMING_HOME", str(tmp_path))
+    monkeypatch.setenv("SIMING_LOG_FILE", "auto")
+
+    configure_logging()
+    assert _owned_handler_names() == {"siming-console", "siming-file"}
+
+
+def test_settings_log_defaults(monkeypatch):
+    from app.core.config import Settings
+
+    for key in (
+        "SIMING_LOG_LEVEL",
+        "SIMING_LOG_FILE",
+        "SIMING_LOG_HTTP_ACCESS",
+        "LOG_LEVEL",
+        "LOG_FILE",
+        "LOG_HTTP_ACCESS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    settings = Settings(_env_file=None)
+    assert settings.log_level == "info"
+    assert settings.log_file == "auto"
+    assert settings.log_http_access is False
+
+
+def test_settings_log_env_overrides(monkeypatch):
+    from app.core.config import Settings
+
+    monkeypatch.setenv("SIMING_LOG_LEVEL", "debug")
+    monkeypatch.setenv("SIMING_LOG_FILE", "1")
+    monkeypatch.setenv("SIMING_LOG_HTTP_ACCESS", "true")
+    settings = Settings(_env_file=None)
+    assert settings.log_level == "debug"
+    assert settings.log_file == "1"
+    assert settings.log_http_access is True
+
+
+def test_general_exception_handler_logs_traceback(caplog):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.core.exceptions import general_exception_handler
+
+    app = FastAPI()
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise RuntimeError("boom-detail")
+
+    app.add_exception_handler(Exception, general_exception_handler)
+    with caplog.at_level(logging.ERROR, logger="app.core.exceptions"):
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/boom")
+    assert response.status_code == 500
+    matched = [
+        record
+        for record in caplog.records
+        if record.name == "app.core.exceptions"
+        and record.levelno >= logging.ERROR
+        and "Unhandled exception" in record.getMessage()
+    ]
+    assert matched
+
+
+def test_system_log_resolution_prefers_runtime_log(tmp_path, monkeypatch):
+    from app.routers.config_storage import _system_log_path
+
+    monkeypatch.setenv("SIMING_HOME", str(tmp_path))
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    launcher_log = log_dir / "launcher.log"
+    launcher_log.write_text("launcher\n", encoding="utf-8")
+    assert _system_log_path() == launcher_log
+
+    siming_log = log_dir / "siming.log"
+    siming_log.write_text("runtime\n", encoding="utf-8")
+    assert _system_log_path() == siming_log
+
+
+def test_console_skipped_when_stderr_unavailable(clean_logging, tmp_path, monkeypatch):
+    monkeypatch.setattr(logging_setup, "_in_pytest_mode", lambda: False)
+    monkeypatch.setattr(sys, "stderr", None)
+    monkeypatch.setenv("SIMING_HOME", str(tmp_path))
+    monkeypatch.setenv("SIMING_LOG_FILE", "1")
+
+    configure_logging()
+    # Windowed GUI builds have no stderr: only the file handler is installed and
+    # logging never falls into StreamHandler exception paths.
+    assert _owned_handler_names() == {"siming-file"}
+
+
+def test_force_configuration_owns_root_handlers(clean_logging, tmp_path, monkeypatch):
+    from logging import StreamHandler
+
+    monkeypatch.setattr(logging_setup, "_in_pytest_mode", lambda: False)
+    monkeypatch.setenv("SIMING_HOME", str(tmp_path))
+    monkeypatch.setenv("SIMING_LOG_FILE", "1")
+
+    # Simulate a foreign handler left on the root logger (Uvicorn's default
+    # dictConfig on the Docker CLI path does exactly this).
+    root = logging.getLogger()
+    foreign = StreamHandler()
+    foreign.name = "foreign-default"
+    root.addHandler(foreign)
+
+    configure_logging(force=True)
+    handler_names = {
+        str(getattr(handler, "name", "") or "")
+        for handler in root.handlers
+    }
+    assert "foreign-default" not in handler_names
+    assert handler_names == {"siming-console", "siming-file"}
+

--- a/backend/tests/test_uvicorn_controller.py
+++ b/backend/tests/test_uvicorn_controller.py
@@ -49,6 +49,7 @@ class UvicornServerControllerTestCase(unittest.TestCase):
             port=9876,
             log_level="info",
             access_log=False,
+            log_config=None,
         )
 
     def test_close_during_app_import_prevents_late_server_start(self):

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -5243,7 +5243,7 @@ export interface paths {
         };
         /**
          * Get System Logs
-         * @description Read the last N lines of the launcher log file.
+         * @description Read the last N lines of the backend runtime or launcher log file.
          */
         get: operations["get_system_logs_api_v1_system_logs_get"];
         put?: never;

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -1,6 +1,7 @@
 /**
  * Terminal / Log viewer page for the desktop GUI.
- * Shows launcher.log output and provides quick actions like opening the home in a browser.
+ * Shows the backend runtime log (logs/siming.log, falling back to
+ * logs/launcher.log) and provides quick actions like opening the home in a browser.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button, Space, Switch, Typography, message } from 'antd'


### PR DESCRIPTION
后端日志增强已完成并通过验证。以下是本次改动总结。

## 改动概览（17 处修改 + 2 个新文件）

### 核心：统一日志基础设施
- **新增 `backend/app/core/logging_setup.py`**：集中式、幂等的日志配置
  - 控制台(stderr) + 文件双通道；文件为 `<数据目录>/logs/siming.log`，`RotatingFileHandler` 5MB×3、utf-8
  - 应用 `app.*` logger 跟随 `SIMING_LOG_LEVEL`（默认 `info`）；第三方库（sqlalchemy/httpx/openai/anthropic 等）压到 `warning` 防刷屏；alembic 迁移进度保持可见
  - pytest 环境自动不装 handler、不写文件（测试框架自己管理捕获）
  - 文件开关 `auto/0/1`：桌面/打包/Gateway 默认落盘，纯源码开发服务器只走 stderr
- **`core/config.py`** 新增 `log_level` / `log_file` / `log_http_access` 三个配置（`SIMING_LOG_*` 环境变量），并同步更新 `.env.example`
- **`bootstrap/app_factory.py`**：`create_app()` 入口统一接入 `configure_logging()`，覆盖 launcher、Docker uvicorn、脚本等所有入口
- **`bootstrap/lifecycle.py`**：应用 lifespan 里 `configure_logging(force=True)`，兜底 Uvicorn 默认 dictConfig 对配置的覆盖
- **`core/uvicorn_controller.py`**：`uvicorn.Config(..., log_config=None)` 交给自有管线，对应测试已同步

### 异常路径（以前 500 直接丢 traceback）
- **`core/exceptions.py`**：未捕获异常 `logger.exception` 记录完整堆栈；业务异常 ≥500 记 error、其余记 warning；参数校验失败记 warning（只记字段路径与消息，不落正文内容）

### HTTP 可观测
- **`backend/launcher.py`**：访问日志开关 `SIMING_LOG_HTTP_ACCESS=1` 时打开 uvicorn access log（默认关闭）

### 关键业务路径补日志（只记 ID/数量/耗时/错误码，不含正文与密钥）
- AI 写作回合（`assistant_turn_runner.py`）：回合开始/完成（run/project/provider/model/模式）
- 建档（`services/cataloging/launcher.py`）：任务入队、worker 启动
- 内容镜像同步（`content_sync.py`）、Gateway 变更捕获（`change_capture.py`）：提交后分发摘要（debug）
- 定时任务（`scheduler/engine.py`）：任务完成耗时
- 本地模型运行时（`services/local_runtime/manager.py`）：就绪/停止/启动失败摘要
- 生命周期（`lifecycle.py`）：数据库引导 mode/revision、调度器启停、本地运行时启停、上下文重建任务

### 让桌面"运行日志"页直接看到新日志
- **`routers/config_storage.py`**：`GET /api/v1/system/logs` 现在优先读 `siming.log`，回退 `launcher.log`；**响应字段不变**（API 契约不变）
- 同步更新前端生成契约注释 `schema.d.ts` 与 `TerminalPage.tsx` 注释

### 测试
- **新增 `backend/tests/test_logging_setup.py`**（8 个用例）：pytest 下零 handler、console+file 安装、幂等性、auto 文件开关、Settings 默认与 env 覆盖、500 处理器确实记录、日志页优先读 siming.log

## 验证结果
- 新增测试 8 passed；改动相关回归测试 **127 passed**（lifecycle/launcher/settings/scheduler/content_sync/database bootstrap/stream runtime/workspace/cataloging/gateway/http_security/openapi 契约等）
- ruff：所有新增与重构文件 **All checks passed**
- import-linter 架构约束 **4 kept / 0 broken**
- `py_compile` 全部通过；`create_app` 冒烟验证日志按 `时间 级别 [logger]` 格式实时写入 `logs/siming.log`

## 使用说明
- 桌面版升级后，应用运行日志自动写到 `<数据目录>/logs/siming.log`，GUI"运行日志"页 3 秒自动刷新可直接看到
- 想查更细可在 `.env`/环境变量设 `SIMING_LOG_LEVEL=debug`；需要逐请求访问日志设 `SIMING_LOG_HTTP_ACCESS=1`；不想要文件日志设 `SIMING_LOG_FILE=0`