### PR TITLE
fix: thinking 模式请求被拒绝时自动关闭思考重试一次（PC/Gateway/Android）

### DIFF
--- a/backend/app/ai/capabilities.py
+++ b/backend/app/ai/capabilities.py
@@ -99,6 +99,50 @@ def should_retry_without_tool_choice(error: BaseException) -> bool:
     return "tool_choice" in text or "tool choice" in text
 
 
+# Provider errors that only exist because the request ran in thinking mode.
+# The pairs are structured provider-protocol markers, not user-language intent:
+# DeepSeek V4 thinking mode requires previous assistant reasoning_content to be
+# passed back when the request carries tools, and rejects OpenAI tool_choice.
+_THINKING_REJECTION_MARKERS: tuple[tuple[str, str], ...] = (
+    ("reasoning_content", "must be passed back"),
+    ("reasoning content", "must be passed back"),
+    ("thinking mode", "tool_choice"),
+    ("thinking mode", "tool choice"),
+    ("thinking mode", "not support"),
+    ("thinking mode", "unsupported"),
+    ("thinking mode", "reject"),
+)
+
+
+def is_thinking_rejection(error: BaseException) -> bool:
+    """Detect provider errors caused specifically by the thinking mode.
+
+    Adapting the provider rejection into this category lets the gateway retry
+    the exact same logical request once with thinking disabled.  The markers
+    are provider error-protocol text (returned verbatim by DeepSeek and other
+    OpenAI-compatible endpoints), never a guess at author intent.
+    """
+    text = str(error).lower()
+    if not text:
+        return False
+    return any(first in text and second in text for first, second in _THINKING_REJECTION_MARKERS)
+
+
+# Request-body switch that disables thinking for providers whose thinking mode
+# is enabled by default (DeepSeek V4).  Only providers with a known, verified
+# disable switch belong here; other OpenAI-compatible endpoints keep their own
+# documented parameters and must not receive a guessed body.
+_THINKING_DISABLE_BODIES: dict[str, dict[str, Any]] = {
+    "deepseek": {"thinking": {"type": "disabled"}},
+}
+
+
+def provider_thinking_disable_body(provider: str) -> dict[str, Any] | None:
+    """Return the extra_body that disables thinking for ``provider``, or None."""
+    body = _THINKING_DISABLE_BODIES.get(provider)
+    return dict(body) if body else None
+
+
 def normalize_retry_count(retry: int | None) -> int:
     """Treat retry as extra attempts, but always make at least one attempt.
 

--- a/backend/app/modules/model_runtime/infrastructure/gateway.py
+++ b/backend/app/modules/model_runtime/infrastructure/gateway.py
@@ -14,8 +14,10 @@ from uuid import uuid4
 from app.ai.anthropic_adapter import AnthropicAdapter
 from app.ai.base import BaseAdapter
 from app.ai.capabilities import (
+    is_thinking_rejection,
     normalize_retry_count,
     provider_capabilities,
+    provider_thinking_disable_body,
     request_meta,
     sanitize_tool_request,
     should_retry_without_tool_choice,
@@ -575,43 +577,54 @@ class LLMGateway:
         )
         attempts = normalize_retry_count(retry)
 
-        async def _call() -> dict:
+        thinking_disable_body = provider_thinking_disable_body(provider)
+
+        async def _call_with(extra_body_value: dict | None, choice: str | dict | None) -> dict:
             return await adapter.chat_completion(
                 messages=messages,
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                extra_body=call_extra_body,
+                extra_body=extra_body_value,
                 tools=safe_tools,
-                tool_choice=safe_tool_choice,
+                tool_choice=choice,
             )
+
+        def _disabled_thinking_body() -> dict | None:
+            if thinking_disable_body is None:
+                return None
+            merged = dict(call_extra_body or {})
+            merged.update(thinking_disable_body)
+            return merged
 
         try:
             result = await cls._call_with_retry(
                 attempts=attempts,
                 timeout_seconds=wait_timeout_seconds,
-                call_factory=_call,
+                call_factory=lambda: _call_with(call_extra_body, safe_tool_choice),
             )
         except LLMError as exc:
-            if safe_tool_choice is not None and should_retry_without_tool_choice(exc):
+            remove_tool_choice = (
+                safe_tool_choice is not None and should_retry_without_tool_choice(exc)
+            )
+            disable_thinking = bool(
+                _disabled_thinking_body() is not None and is_thinking_rejection(exc)
+            )
+            if not remove_tool_choice and not disable_thinking:
+                raise
+            choice = None if remove_tool_choice else safe_tool_choice
+            extra_body_value = _disabled_thinking_body() if disable_thinking else call_extra_body
+            if remove_tool_choice:
                 notes.append("接口拒绝 tool_choice，已自动去掉该参数重试")
-                try:
-                    result = await cls._call_with_retry(
-                        attempts=1,
-                        timeout_seconds=wait_timeout_seconds,
-                        call_factory=lambda: adapter.chat_completion(
-                            messages=messages,
-                            model=model_name,
-                            temperature=temperature,
-                            max_tokens=max_tokens,
-                            extra_body=call_extra_body,
-                            tools=safe_tools,
-                            tool_choice=None,
-                        ),
-                    )
-                except LLMError:
-                    raise
-            else:
+            if disable_thinking:
+                notes.append("模型思考模式请求被上游拒绝，已自动关闭思考模式重试一次")
+            try:
+                result = await cls._call_with_retry(
+                    attempts=1,
+                    timeout_seconds=wait_timeout_seconds,
+                    call_factory=lambda: _call_with(extra_body_value, choice),
+                )
+            except LLMError:
                 raise
 
         result.setdefault("model", model_name)
@@ -816,6 +829,8 @@ class LLMGateway:
         )
         raw_retries_remaining = attempts - 1
         resume_attempt = 0
+        thinking_retry_used = False
+        thinking_disable_body = provider_thinking_disable_body(provider)
         last_error: BaseException | None = None
         committed_parts: list[str] = []
         request_messages = messages
@@ -893,14 +908,36 @@ class LLMGateway:
                 last_error = exc
                 error_cause = exc
                 if (
-                    safe_tool_choice is not None
+                    not raw_produced
+                    and safe_tool_choice is not None
                     and should_retry_without_tool_choice(exc)
-                    and not raw_produced
                 ):
                     notes.append("接口拒绝 tool_choice，已自动去掉该参数重试")
                     safe_tool_choice = None
+                elif (
+                    not raw_produced
+                    and not thinking_retry_used
+                    and thinking_disable_body is not None
+                    and is_thinking_rejection(exc)
+                ):
+                    # DeepSeek V4 thinking mode rejects requests whose replayed
+                    # assistant messages carry no reasoning_content.  Retry the
+                    # exact same logical step once with thinking disabled.
+                    thinking_retry_used = True
+                    notes.append("模型思考模式请求被上游拒绝，已自动关闭思考模式重试一次")
+                    call_extra_body = dict(call_extra_body or {})
+                    call_extra_body.update(thinking_disable_body)
+                    last_error = None
+                    continue
                 else:
-                    non_retryable = _is_non_retryable(exc)
+                    non_retryable = _is_non_retryable(exc) or (
+                        thinking_retry_used and is_thinking_rejection(exc)
+                    )
+                    if thinking_retry_used and is_thinking_rejection(exc):
+                        last_error = LLMError(
+                            "模型思考模式请求被上游拒绝，已自动关闭思考模式重试一次，"
+                            "重试仍被拒绝；请新建对话或改用非思考模式模型后重试。"
+                        )
             except Exception as exc:
                 last_error = LLMError(f"流式调用失败: {exc}")
                 error_cause = exc

--- a/backend/app/modules/model_runtime/infrastructure/gateway.py
+++ b/backend/app/modules/model_runtime/infrastructure/gateway.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import suppress
-from dataclasses import dataclass
 from inspect import isawaitable
 from typing import TypeVar
 from uuid import uuid4
@@ -44,6 +42,11 @@ from .local_cli import (
     effective_local_cli_model,
     is_local_cli_provider,
 )
+from .tool_stream import (
+    _consume_tool_stream_attempt,
+    _ResumeHandshake,
+    _ResumeHandshakeError,
+)
 
 ADAPTER_MAP: dict[str, type[BaseAdapter]] = {
     "openai": OpenAIAdapter,
@@ -71,36 +74,6 @@ DEFAULT_STREAM_RESUMES = 8
 STREAM_RESUME_ANCHOR_CHARS = 64
 T = TypeVar("T")
 
-
-class _ResumeHandshakeError(LLMError):
-    """The replacement stream did not prove that it starts at our checkpoint."""
-
-
-@dataclass
-class _ResumeHandshake:
-    expected_prefix: str
-    buffered: str = ""
-    verified: bool = False
-
-    def consume(self, chunk: str) -> str:
-        if self.verified:
-            return chunk
-        self.buffered += chunk
-        candidate = self.buffered.lstrip()
-        if len(candidate) < len(self.expected_prefix):
-            if not self.expected_prefix.startswith(candidate):
-                raise _ResumeHandshakeError("模型没有按检查点恢复协议继续输出")
-            return ""
-        if not candidate.startswith(self.expected_prefix):
-            raise _ResumeHandshakeError("模型没有按检查点恢复协议继续输出")
-        self.verified = True
-        suffix = candidate[len(self.expected_prefix):]
-        self.buffered = ""
-        return suffix
-
-    def require_verified(self) -> None:
-        if not self.verified:
-            raise _ResumeHandshakeError("模型恢复响应在检查点握手完成前结束")
 
 
 def _normalize_stream_resumes(resume: int | None) -> int:
@@ -172,58 +145,6 @@ def _resume_messages(
     rendered = _append_system_instruction(messages, instruction)
     rendered.append({"role": "user", "content": "继续中断的同一模型步骤。"})
     return rendered, None
-
-
-def _tool_delta_events_complete(events: list[dict]) -> bool:
-    if not events:
-        return True
-    calls: dict[int, dict[str, str]] = {}
-    for event in events:
-        index = int(event.get("index") or 0)
-        call = calls.setdefault(index, {"name": "", "arguments": ""})
-        if event.get("name"):
-            call["name"] = str(event["name"])
-        if event.get("arguments_delta"):
-            call["arguments"] += str(event["arguments_delta"])
-    for call in calls.values():
-        if not call["name"]:
-            return False
-        if not call["arguments"]:
-            return False
-        try:
-            arguments = json.loads(call["arguments"])
-        except (TypeError, ValueError, json.JSONDecodeError):
-            return False
-        if not isinstance(arguments, dict):
-            return False
-    return True
-
-
-def _validate_tool_stream_completion(
-    done_event: dict | None,
-    buffered_tool_events: list[dict],
-    handshake: _ResumeHandshake | None,
-    content_seen: bool,
-    usage_totals: dict[str, int],
-    has_usage: bool,
-) -> bool:
-    if handshake and content_seen:
-        handshake.require_verified()
-    if done_event is None:
-        raise _ResumeHandshakeError("模型工具流在正式结束帧到达前停止")
-    raw_usage = done_event.get("usage")
-    if isinstance(raw_usage, dict):
-        has_usage = True
-        for key in usage_totals:
-            usage_totals[key] += max(0, int(raw_usage.get(key) or 0))
-    finish_reason = str(done_event.get("finish_reason") or "").lower()
-    if finish_reason in {"length", "max_tokens", "token_limit", "incomplete"}:
-        raise _ResumeHandshakeError("模型输出达到单次长度上限，正在从检查点继续")
-    if not _tool_delta_events_complete(buffered_tool_events):
-        raise _ResumeHandshakeError("工具调用在参数完整前结束")
-    if handshake and not content_seen and not buffered_tool_events:
-        handshake.require_verified()
-    return has_usage
 
 
 def _record_stream_resume(
@@ -839,10 +760,8 @@ class LLMGateway:
         has_usage = False
 
         while True:
-            raw_produced = False
-            content_seen = False
-            buffered_tool_events: list[dict] = []
-            done_event: dict | None = None
+            received_any = [False]
+            has_usage_tracker = [has_usage]
             error_cause: BaseException | None = None
             non_retryable = False
             gen: AsyncGenerator[dict, None] | None = None
@@ -856,50 +775,21 @@ class LLMGateway:
                     tools=safe_tools,
                     tool_choice=safe_tool_choice,
                 )
-                while True:
-                    try:
-                        chunk = await cls._next_stream_item(gen, wait_timeout_seconds)
-                    except StopAsyncIteration:
-                        break
-                    raw_produced = True
-                    event_type = chunk.get("type")
-                    if event_type == "content_delta":
-                        delta = str(chunk.get("delta") or "")
-                        content_seen = content_seen or bool(delta)
-                        outgoing = handshake.consume(delta) if handshake else delta
-                        if outgoing:
-                            committed_parts.append(outgoing)
-                            yielded = dict(chunk)
-                            yielded["delta"] = outgoing
-                            yield yielded
-                    elif event_type == "tool_call_delta":
-                        buffered_tool_events.append(dict(chunk))
-                    elif event_type == "done":
-                        done_event = dict(chunk)
-                        with suppress(Exception):
-                            await gen.aclose()
-                        break
-                    else:
-                        yield chunk
-
-                has_usage = _validate_tool_stream_completion(
-                    done_event,
-                    buffered_tool_events,
-                    handshake,
-                    content_seen,
-                    usage_totals,
-                    has_usage,
-                )
-
-                for tool_event in buffered_tool_events:
-                    yield tool_event
-                if done_event is not None:
-                    if has_usage:
-                        done_event["usage"] = dict(usage_totals)
-                    if resume_attempt:
-                        notes.append(f"流式响应已从检查点续传 {resume_attempt} 次")
-                    done_event.setdefault("request_meta", request_meta(provider, model_name, notes))
-                    yield done_event
+                async for chunk in _consume_tool_stream_attempt(
+                    generator=gen,
+                    handshake=handshake,
+                    committed_parts=committed_parts,
+                    usage_totals=usage_totals,
+                    has_usage_tracker=has_usage_tracker,
+                    received_tracker=received_any,
+                    provider=provider,
+                    model_name=model_name,
+                    notes=notes,
+                    resume_attempt=resume_attempt,
+                    timeout_seconds=wait_timeout_seconds,
+                ):
+                    yield chunk
+                has_usage = has_usage_tracker[0]
                 return
             except TimeoutError as exc:
                 last_error = LLMError(f"流式请求超时（{timeout_seconds or '未限制'}秒）")
@@ -908,14 +798,14 @@ class LLMGateway:
                 last_error = exc
                 error_cause = exc
                 if (
-                    not raw_produced
+                    not received_any[0]
                     and safe_tool_choice is not None
                     and should_retry_without_tool_choice(exc)
                 ):
                     notes.append("接口拒绝 tool_choice，已自动去掉该参数重试")
                     safe_tool_choice = None
                 elif (
-                    not raw_produced
+                    not received_any[0]
                     and not thinking_retry_used
                     and thinking_disable_body is not None
                     and is_thinking_rejection(exc)
@@ -948,17 +838,16 @@ class LLMGateway:
 
             if non_retryable:
                 raise last_error from error_cause
-            if not raw_produced and raw_retries_remaining > 0:
+            if not received_any[0] and raw_retries_remaining > 0:
                 raw_retries_remaining -= 1
                 await asyncio.sleep(min(8, (attempts - raw_retries_remaining) * 1.5))
                 continue
 
             committed_text = "".join(committed_parts)
             can_resume = resumes_remaining > 0 and (
-                raw_produced
+                received_any[0]
                 or handshake is not None
                 or bool(committed_text)
-                or bool(buffered_tool_events)
             )
             if can_resume:
                 resumes_remaining -= 1

--- a/backend/app/modules/model_runtime/infrastructure/tool_stream.py
+++ b/backend/app/modules/model_runtime/infrastructure/tool_stream.py
@@ -1,0 +1,181 @@
+"""Shared resume/validation helpers for one provider tool-stream attempt.
+
+Kept in their own module so the LLM gateway stays under the architecture
+module-size limit.  These helpers are pure provider-protocol utilities: they
+consume adapter SSE events, validate that a native tool batch completed, and
+re-emit the final ``done`` event with cumulative usage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from contextlib import suppress
+from dataclasses import dataclass
+
+from app.ai.capabilities import request_meta
+from app.core.exceptions import LLMError
+
+
+class _ResumeHandshakeError(LLMError):
+    """The replacement stream did not prove that it starts at our checkpoint."""
+
+
+@dataclass
+class _ResumeHandshake:
+    expected_prefix: str
+    buffered: str = ""
+    verified: bool = False
+
+    def consume(self, chunk: str) -> str:
+        if self.verified:
+            return chunk
+        self.buffered += chunk
+        candidate = self.buffered.lstrip()
+        if len(candidate) < len(self.expected_prefix):
+            if not self.expected_prefix.startswith(candidate):
+                raise _ResumeHandshakeError("模型没有按检查点恢复协议继续输出")
+            return ""
+        if not candidate.startswith(self.expected_prefix):
+            raise _ResumeHandshakeError("模型没有按检查点恢复协议继续输出")
+        self.verified = True
+        suffix = candidate[len(self.expected_prefix):]
+        self.buffered = ""
+        return suffix
+
+    def require_verified(self) -> None:
+        if not self.verified:
+            raise _ResumeHandshakeError("模型恢复响应在检查点握手完成前结束")
+
+
+def _tool_delta_events_complete(events: list[dict]) -> bool:
+    if not events:
+        return True
+    calls: dict[int, dict[str, str]] = {}
+    for event in events:
+        index = int(event.get("index") or 0)
+        call = calls.setdefault(index, {"name": "", "arguments": ""})
+        if event.get("name"):
+            call["name"] = str(event["name"])
+        if event.get("arguments_delta"):
+            call["arguments"] += str(event["arguments_delta"])
+    for call in calls.values():
+        if not call["name"]:
+            return False
+        if not call["arguments"]:
+            return False
+        try:
+            arguments = json.loads(call["arguments"])
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return False
+        if not isinstance(arguments, dict):
+            return False
+    return True
+
+
+def _validate_tool_stream_completion(
+    done_event: dict | None,
+    buffered_tool_events: list[dict],
+    handshake: _ResumeHandshake | None,
+    content_seen: bool,
+    usage_totals: dict[str, int],
+    has_usage: bool,
+) -> bool:
+    if handshake and content_seen:
+        handshake.require_verified()
+    if done_event is None:
+        raise _ResumeHandshakeError("模型工具流在正式结束帧到达前停止")
+    raw_usage = done_event.get("usage")
+    if isinstance(raw_usage, dict):
+        has_usage = True
+        for key in usage_totals:
+            usage_totals[key] += max(0, int(raw_usage.get(key) or 0))
+    finish_reason = str(done_event.get("finish_reason") or "").lower()
+    if finish_reason in {"length", "max_tokens", "token_limit", "incomplete"}:
+        raise _ResumeHandshakeError("模型输出达到单次长度上限，正在从检查点继续")
+    if not _tool_delta_events_complete(buffered_tool_events):
+        raise _ResumeHandshakeError("工具调用在参数完整前结束")
+    if handshake and not content_seen and not buffered_tool_events:
+        handshake.require_verified()
+    return has_usage
+
+
+async def _consume_tool_stream_attempt(
+    *,
+    generator: AsyncGenerator[dict, None],
+    handshake: _ResumeHandshake | None,
+    committed_parts: list[str],
+    usage_totals: dict[str, int],
+    has_usage_tracker: list[bool],
+    received_tracker: list[bool],
+    provider: str,
+    model_name: str,
+    notes: list[str],
+    resume_attempt: int,
+    timeout_seconds: int | None,
+) -> AsyncGenerator[dict, None]:
+    """Consume one adapter tool stream and yield its caller-visible events.
+
+    Content deltas are emitted live, tool deltas are buffered until the provider
+    closes the batch, and the final ``done`` event is re-emitted with cumulative
+    usage.  Any provider/validation failure propagates to the retry loop.
+    """
+    content_seen = False
+    buffered_tool_events: list[dict] = []
+    done_event: dict | None = None
+    while True:
+        try:
+            if timeout_seconds is None:
+                chunk = await generator.__anext__()
+            else:
+                chunk = await asyncio.wait_for(generator.__anext__(), timeout=timeout_seconds)
+        except StopAsyncIteration:
+            break
+        received_tracker[0] = True
+        event_type = chunk.get("type")
+        if event_type == "content_delta":
+            delta = str(chunk.get("delta") or "")
+            content_seen = content_seen or bool(delta)
+            outgoing = handshake.consume(delta) if handshake else delta
+            if outgoing:
+                committed_parts.append(outgoing)
+                yielded = dict(chunk)
+                yielded["delta"] = outgoing
+                yield yielded
+        elif event_type == "tool_call_delta":
+            buffered_tool_events.append(dict(chunk))
+        elif event_type == "done":
+            done_event = dict(chunk)
+            with suppress(Exception):
+                await generator.aclose()
+            break
+        else:
+            yield chunk
+
+    has_usage_tracker[0] = _validate_tool_stream_completion(
+        done_event,
+        buffered_tool_events,
+        handshake,
+        content_seen,
+        usage_totals,
+        has_usage_tracker[0],
+    )
+    for tool_event in buffered_tool_events:
+        yield tool_event
+    if done_event is not None:
+        if has_usage_tracker[0]:
+            done_event["usage"] = dict(usage_totals)
+        if resume_attempt:
+            notes.append(f"流式响应已从检查点续传 {resume_attempt} 次")
+        done_event.setdefault("request_meta", request_meta(provider, model_name, notes))
+        yield done_event
+
+
+__all__ = [
+    "_ResumeHandshake",
+    "_ResumeHandshakeError",
+    "_consume_tool_stream_attempt",
+    "_tool_delta_events_complete",
+    "_validate_tool_stream_completion",
+]

--- a/backend/tests/test_gateway_thinking_degrade.py
+++ b/backend/tests/test_gateway_thinking_degrade.py
@@ -1,0 +1,159 @@
+"""Gateway retry once with thinking disabled after a thinking-mode rejection.
+
+DeepSeek V4 thinking mode rejects requests that carry tools while replaying
+assistant messages without ``reasoning_content``.  The gateway must retry the
+exact same logical step once with thinking disabled instead of failing the
+author's turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.ai.base import BaseAdapter
+from app.ai.capabilities import (
+    is_thinking_rejection,
+    provider_thinking_disable_body,
+)
+from app.core.exceptions import LLMError
+from app.modules.model_runtime.infrastructure import gateway as gateway_module
+from app.modules.model_runtime.infrastructure.gateway import LLMGateway
+
+_THINKING_REJECTION = (
+    "DeepSeek API 错误: "
+    '{"error":{"message":"The `reasoning_content` in the thinking mode '
+    'must be passed back to the API.","type":"invalid_request_error",'
+    '"code":"invalid_request_error"}}'
+)
+_UNRELATED_REJECTION = (
+    "DeepSeek API 错误: "
+    '{"error":{"message":"bad request","type":"invalid_request_error"}}'
+)
+
+
+class ThinkingProbeAdapter(BaseAdapter):
+    provider = "deepseek"
+    behaviors: list[str] = []
+    bodies: list[dict | None] = []
+    calls = 0
+
+    @property
+    def provider_name(self) -> str:
+        return type(self).provider
+
+    async def chat_completion(self, **_kwargs):
+        raise LLMError("unexpected chat_completion call")
+
+    async def stream_chat_completion(self, **_kwargs):
+        raise LLMError("unexpected text stream call")
+
+    async def stream_chat_completion_with_tools(self, **kwargs):
+        type(self).calls += 1
+        type(self).bodies.append(kwargs.get("extra_body"))
+        behavior = type(self).behaviors.pop(0)
+        if behavior == "reject_thinking":
+            raise LLMError(_THINKING_REJECTION)
+        if behavior == "reject_unrelated":
+            raise LLMError(_UNRELATED_REJECTION)
+        yield {"type": "done", "finish_reason": "stop", "usage": None}
+
+
+@pytest.fixture(autouse=True)
+def isolated_gateway(monkeypatch):
+    ThinkingProbeAdapter.behaviors = []
+    ThinkingProbeAdapter.bodies = []
+    ThinkingProbeAdapter.calls = 0
+    config = SimpleNamespace(
+        api_key="test-key",
+        base_url="https://api.deepseek.com",
+        provider="deepseek",
+        api_protocol="chat_completions",
+        cli_command=None,
+        cli_args=None,
+    )
+    monkeypatch.setattr(
+        LLMGateway,
+        "_parse_model",
+        staticmethod(lambda _model: ("deepseek", "deepseek-v4-flash")),
+    )
+    monkeypatch.setattr(LLMGateway, "_load_config", staticmethod(lambda _provider: config))
+    monkeypatch.setattr(
+        LLMGateway,
+        "_get_adapter",
+        staticmethod(lambda _provider: ThinkingProbeAdapter),
+    )
+    monkeypatch.setattr(gateway_module.asyncio, "sleep", lambda _seconds: None)
+
+
+async def _collect_tools() -> tuple[list[dict], LLMError | None]:
+    received: list[dict] = []
+    try:
+        async for item in LLMGateway.stream_chat_completion_with_tools(
+            messages=[{"role": "user", "content": "probe"}],
+            model="deepseek:deepseek-v4-flash",
+            timeout=0,
+            retry=0,
+            tools=[{
+                "type": "function",
+                "function": {"name": "read", "parameters": {"type": "object"}},
+            }],
+        ):
+            received.append(item)
+    except LLMError as exc:
+        return received, exc
+    return received, None
+
+
+def test_capabilities_classify_thinking_rejections() -> None:
+    assert is_thinking_rejection(LLMError(_THINKING_REJECTION))
+    assert is_thinking_rejection(
+        LLMError("{\"message\":\"Thinking mode does not support this tool choice\"}")
+    )
+    assert not is_thinking_rejection(LLMError(_UNRELATED_REJECTION))
+    assert not is_thinking_rejection(LLMError("quota exceeded"))
+
+
+def test_thinking_disable_body_only_for_known_provider() -> None:
+    assert provider_thinking_disable_body("deepseek") == {"thinking": {"type": "disabled"}}
+    assert provider_thinking_disable_body("openai") is None
+    assert provider_thinking_disable_body("siliconflow") is None
+
+
+def test_tool_stream_retries_once_with_thinking_disabled() -> None:
+    ThinkingProbeAdapter.behaviors = ["reject_thinking", "ok"]
+
+    received, error = asyncio.run(_collect_tools())
+
+    assert error is None
+    done = received[-1]
+    assert done["type"] == "done"
+    assert ThinkingProbeAdapter.calls == 2
+    assert ThinkingProbeAdapter.bodies[0] is None
+    assert ThinkingProbeAdapter.bodies[1] == {"thinking": {"type": "disabled"}}
+    adjustments = done["request_meta"]["adjustments"]
+    assert any("关闭思考模式" in note for note in adjustments)
+
+
+def test_tool_stream_degrades_only_once_then_fails_readably() -> None:
+    ThinkingProbeAdapter.behaviors = ["reject_thinking", "reject_thinking"]
+
+    received, error = asyncio.run(_collect_tools())
+
+    assert received == []
+    assert isinstance(error, LLMError)
+    assert "关闭思考模式重试一次" in str(error)
+    assert "请新建对话" in str(error)
+    assert ThinkingProbeAdapter.calls == 2
+
+
+def test_unrelated_rejection_is_not_degraded() -> None:
+    ThinkingProbeAdapter.behaviors = ["reject_unrelated"]
+
+    received, error = asyncio.run(_collect_tools())
+
+    assert received == []
+    assert isinstance(error, LLMError)
+    assert ThinkingProbeAdapter.calls == 1

--- a/backend/tests/test_provider_native_tool_protocol.py
+++ b/backend/tests/test_provider_native_tool_protocol.py
@@ -26,7 +26,7 @@ from app.ai.openai_adapter import (
     _responses_input,
     _responses_tool_calls,
 )
-from app.modules.model_runtime.infrastructure.gateway import _tool_delta_events_complete
+from app.modules.model_runtime.infrastructure.tool_stream import _tool_delta_events_complete
 from app.services.agent_tool_stream import collect_tool_turn
 from app.services.conversation_context import (
     ConversationContextError,

--- a/contracts/mobile-pc-parity.json
+++ b/contracts/mobile-pc-parity.json
@@ -210,7 +210,7 @@
               "contains": "private fun providerSafeToolChoice("
             }
           ],
-          "limitations": "提示词、工具 schema、宽粒度类别控制器与版本化上下文策略均由 PC 源生成；模型正文、推理和函数参数使用供应商 SSE 真流式解析，thinking 模型沿用 PC 的 provider-safe tool_choice 规则并在接口明确拒绝时于输出前自动去参重试，章节草稿、完整 ContextManifest、通用会话转录与工具日志均可跨重启恢复。独立运行仍不进入 PC 的数据库级 AgentRun 审计，检索仍是确定性词法降级。"
+          "limitations": "提示词、工具 schema、宽粒度类别控制器与版本化上下文策略均由 PC 源生成；模型正文、推理和函数参数使用供应商 SSE 真流式解析，thinking 模型沿用 PC 的 provider-safe tool_choice 规则并在接口明确拒绝时于输出前自动去参重试；请求因 thinking 模式（如历史 reasoning_content 缺失或参数冲突）在输出前被拒绝时，PC 与手机都会先自动关闭思考模式重试一次，章节草稿、完整 ContextManifest、通用会话转录与工具日志均可跨重启恢复。独立运行仍不进入 PC 的数据库级 AgentRun 审计，检索仍是确定性词法降级。"
         }
       },
       "side_effects": [],

--- a/docs/mobile-pc-parity.md
+++ b/docs/mobile-pc-parity.md
@@ -49,7 +49,7 @@ PC 是小说数据、领域副作用和上下文治理的唯一权威实现。An
 - **PC：** PC 权威实现
 - **Android 在线：** 调用 PC 权威接口
 - **Android 离线：** 明确阻止：没有 Gateway 且未配置手机直连模型时不启动 Agent。
-- **Android 独立 Agent：** 明确降级实现：提示词、工具 schema、宽粒度类别控制器与版本化上下文策略均由 PC 源生成；模型正文、推理和函数参数使用供应商 SSE 真流式解析，thinking 模型沿用 PC 的 provider-safe tool_choice 规则并在接口明确拒绝时于输出前自动去参重试，章节草稿、完整 ContextManifest、通用会话转录与工具日志均可跨重启恢复。独立运行仍不进入 PC 的数据库级 AgentRun 审计，检索仍是确定性词法降级。
+- **Android 独立 Agent：** 明确降级实现：提示词、工具 schema、宽粒度类别控制器与版本化上下文策略均由 PC 源生成；模型正文、推理和函数参数使用供应商 SSE 真流式解析，thinking 模型沿用 PC 的 provider-safe tool_choice 规则并在接口明确拒绝时于输出前自动去参重试；请求因 thinking 模式（如历史 reasoning_content 缺失或参数冲突）在输出前被拒绝时，PC 与手机都会先自动关闭思考模式重试一次，章节草稿、完整 ContextManifest、通用会话转录与工具日志均可跨重启恢复。独立运行仍不进入 PC 的数据库级 AgentRun 审计，检索仍是确定性词法降级。
 - **已知缺口：**
   - 手机独立 Agent 的章节草稿、通用对话和工具日志已支持跨重启恢复，但独立运行不会伪装成 PC 数据库中的 AgentRun 审计记录。
 

--- a/mobile/android/app/src/main/java/com/siming/mobile/data/network/DirectApi.kt
+++ b/mobile/android/app/src/main/java/com/siming/mobile/data/network/DirectApi.kt
@@ -429,6 +429,8 @@ class DirectApiClient(
             "chat/completions"
         }
         var effectiveToolChoice = providerSafeToolChoice(config, toolChoice)
+        var effectiveExtraBody = extraBody
+        var thinkingRetryUsed = false
         var lastError: Throwable? = null
         endpointLoop@ for (endpoint in endpointCandidates(config.baseUrl, path)) {
             while (true) {
@@ -440,7 +442,7 @@ class DirectApiClient(
                         toolChoice = effectiveToolChoice,
                         maxOutputTokens = maxOutputTokens,
                         temperature = temperature,
-                        extraBody = extraBody,
+                        extraBody = effectiveExtraBody,
                     )
                     val response = executeWithRetry(endpoint, config.apiKey, json.encodeToString(payload))
                     if (response.statusCode in PATH_FALLBACK_STATUS_CODES) break
@@ -456,6 +458,13 @@ class DirectApiClient(
                     lastError = error
                     if (effectiveToolChoice != null && error.isToolChoiceRejection()) {
                         effectiveToolChoice = null
+                        continue
+                    }
+                    val disabledThinkingBody = thinkingDisabledExtraBody(config, effectiveExtraBody)
+                    if (!thinkingRetryUsed && disabledThinkingBody != null && error.isThinkingRejection()) {
+                        thinkingRetryUsed = true
+                        effectiveExtraBody = disabledThinkingBody
+                        lastError = null
                         continue
                     }
                     if (error is DirectApiHttpException && error.statusCode in PATH_FALLBACK_STATUS_CODES) {
@@ -497,6 +506,8 @@ class DirectApiClient(
             "chat/completions"
         }
         var effectiveToolChoice = providerSafeToolChoice(config, toolChoice)
+        var effectiveExtraBody = extraBody
+        var thinkingRetryUsed = false
         var visibleOutputEmitted = false
         var lastError: Throwable? = null
         endpointLoop@ for (endpoint in endpointCandidates(config.baseUrl, path)) {
@@ -508,7 +519,7 @@ class DirectApiClient(
                     toolChoice = effectiveToolChoice,
                     maxOutputTokens = maxOutputTokens,
                     temperature = temperature,
-                    extraBody = extraBody,
+                    extraBody = effectiveExtraBody,
                     stream = true,
                 )
                 try {
@@ -537,6 +548,18 @@ class DirectApiClient(
                         effectiveToolChoice = null
                         continue
                     }
+                    val disabledThinkingBody = thinkingDisabledExtraBody(config, effectiveExtraBody)
+                    if (
+                        !thinkingRetryUsed &&
+                        !visibleOutputEmitted &&
+                        disabledThinkingBody != null &&
+                        error.isThinkingRejection()
+                    ) {
+                        thinkingRetryUsed = true
+                        effectiveExtraBody = disabledThinkingBody
+                        lastError = null
+                        continue
+                    }
                     if (error is DirectApiHttpException && error.statusCode in PATH_FALLBACK_STATUS_CODES) {
                         break
                     }
@@ -562,6 +585,38 @@ class DirectApiClient(
         if (this !is DirectApiHttpException) return false
         val detail = message.orEmpty().lowercase()
         return "tool_choice" in detail || "tool choice" in detail
+    }
+
+    private fun Throwable.isThinkingRejection(): Boolean {
+        if (this !is DirectApiHttpException) return false
+        val detail = message.orEmpty().lowercase()
+        return (
+            "reasoning_content" in detail && "must be passed back" in detail
+        ) || (
+            "thinking mode" in detail && (
+                "tool_choice" in detail ||
+                    "tool choice" in detail ||
+                    "not support" in detail ||
+                    "unsupported" in detail ||
+                    "reject" in detail
+                )
+            )
+    }
+
+    /**
+     * One DeepSeek recovery attempt: disable V4 thinking after a thinking-mode
+     * rejection. Only DeepSeek has a verified disable switch; other providers
+     * keep their own documented parameters and return null here.
+     */
+    private fun thinkingDisabledExtraBody(
+        config: DirectApiConfig,
+        extraBody: JsonObject?,
+    ): JsonObject? {
+        if (!config.isDeepSeekProvider()) return null
+        return buildJsonObject {
+            extraBody?.forEach { (key, value) -> put(key, value) }
+            put("thinking", buildJsonObject { put("type", "disabled") })
+        }
     }
 
     /**

--- a/mobile/android/app/src/test/java/com/siming/mobile/data/network/DirectApiClientTest.kt
+++ b/mobile/android/app/src/test/java/com/siming/mobile/data/network/DirectApiClientTest.kt
@@ -538,6 +538,45 @@ class DirectApiClientTest {
     }
 
     @Test
+    fun `chat agent stream retries once with thinking disabled after reasoning pass-back rejection`() {
+        val attempts = AtomicInteger()
+        withServer(
+            object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    val body = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+                    return if (attempts.incrementAndGet() == 1) {
+                        jsonResponse(
+                            """{"error":{"message":"The `reasoning_content` in the thinking mode must be passed back to the API.","type":"invalid_request_error"}}""",
+                            400,
+                        )
+                    } else {
+                        assertEquals(
+                            "disabled",
+                            body.getValue("thinking").jsonObject.getValue("type").jsonPrimitive.content,
+                        )
+                        sseResponse(
+                            """{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-deepseek-reasoning","function":{"name":"get_project_info","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}""",
+                        )
+                    }
+                }
+            },
+        ) { server ->
+            val turn = runBlocking {
+                testClient().streamAgentTurn(
+                    config(server, DirectApiConfig.PROTOCOL_CHAT_COMPLETIONS).copy(
+                        displayName = "DeepSeek",
+                        model = "deepseek-v4-flash",
+                    ),
+                    messages = listOf(buildJsonObject { put("role", "user"); put("content", "读取") }),
+                    tools = singleTool("get_project_info"),
+                )
+            }
+            assertEquals("get_project_info", turn.toolCalls.single().name)
+            assertEquals(2, attempts.get())
+        }
+    }
+
+    @Test
     fun `responses agent turn retries once without rejected tool choice`() {
         val attempts = AtomicInteger()
         withServer(


### PR DESCRIPTION
# 修复 DeepSeek V4 思考模式多轮对话被 400 拒绝
## 背景

项目助手在官方 DeepSeek V4（默认开启 thinking）+ 原生工具协议下，同一对话第二次及以后提问时，上游返回：

```
The `reasoning_content` in the thinking mode must be passed back to the API.
invalid_request_error (400)
```

DeepSeek 官方规定：**请求携带 `tools` 且处于 thinking 模式时，历史 assistant 消息必须原样回传 `reasoning_content`**。应用侧 3.3.9 引入的精确回合回放（`conversation_context_frame.v1`）重建历史 assistant 消息时只带 `content`，不保存/回传该字段；3.3.12 将 DeepSeek 身份从 `deepseek-v3` 规范为默认开 thinking 的 `deepseek-v4-flash` 后问题被引爆。老会话几乎必然触发，SiliconFlow 等宽松兼容端点目前不受影响。

## 方案（已确认）

不做全局关闭 thinking；只在**上游因 thinking 模式在输出前明确拒绝**时，把同一逻辑请求**自动关闭思考重试一次**，仍失败则给出可读错误。触发条件按供应商错误协议特征分类（非用户语义猜测）：

- `reasoning_content` + `must be passed back`
- `thinking mode` + `tool_choice` / `not support` / `reject` 等冲突

仅官方 DeepSeek 提供已验证的禁用开关（`{"thinking":{"type":"disabled"}}`）；其余厂商返回不可降级，不做猜测性请求体。

## 改动

### 后端（PC / Gateway）
- `backend/app/ai/capabilities.py`
  - 新增 `is_thinking_rejection()`：thinking 类拒绝分类。
  - 新增 `provider_thinking_disable_body()`：DeepSeek 的关思考 body。
- `backend/app/modules/model_runtime/infrastructure/tool_stream.py`（新增）
  - 迁出工具流消费/校验/续传握手的纯工具代码，使 gateway 模块保持架构规模内。
- `backend/app/modules/model_runtime/infrastructure/gateway.py`
  - `stream_chat_completion_with_tools()` / `chat_completion()`：输出前收到 thinking 类拒绝时，带 `thinking.type=disabled` 重试一次；二次仍被拒则报可读错误，不再死循环。
  - 抽出 `_consume_tool_stream_attempt` 等，方法降至 142 行、模块 876 行。
- `backend/tests/test_provider_native_tool_protocol.py`：导入路径同步。

### 移动端独立 Agent（与 PC 同契约）
- `mobile/android/.../network/DirectApi.kt`
  - 新增 `isThinkingRejection()`、`thinkingDisabledExtraBody()`（仅 DeepSeek 身份）。
  - `agentTurn` / `streamAgentTurn`：输出前 thinking 拒绝 → 自动关思考重试一次。
- `mobile/android/.../network/DirectApiClientTest.kt`：新增“reasoning_content 回传被拒 → 自动降级重试”用例。

### 文档 / 契约
- `docs/mobile-pc-parity.md`、`contracts/mobile-pc-parity.json`：记录 PC 与手机统一的 thinking 拒绝降级行为。

## 测试

- 新增 `backend/tests/test_gateway_thinking_degrade.py`：分类、降级一次成功、二次仍失败可读报错、无关错误不降级。
- 本地（Python 3.11 + 锁定依赖）：
  - ruff：通过
  - 相关 pytest：**50 passed**
  - `scripts/check-architecture.py`：**errors=0**
  - `backend/scripts/run_quality.py`：**exit 0**
- Android 用例建议在 `mobile-ci` 执行确认。

## 行为影响与边界

- 仅“输出前”的 thinking 类拒绝触发降级；已输出后的中断仍走既有 resume/checkpoint。
- 存量老会话在官方 DeepSeek 上可恢复可用；其每个带工具步骤仍会先被拒一次再以关思考重试成功（C 方案已知代价）。
- SiliconFlow 等宽松端点不受影响，无请求体猜测。
- 属异常自愈恢复路径，不改变正常 thinking 请求，不引入常驻业务分支。

